### PR TITLE
feat: continue training from existing model + chart fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,16 @@
 NEXT_PUBLIC_APP_URL=https://wrytes.io
 NEXT_PUBLIC_API_URL=https://api.wrytes.io
 NEXT_PUBLIC_INDEXER_URL=https://indexer.wrytes.io
+NEXT_PUBLIC_DERIBIT_AGENT_URL=https://deribit-agent.api.wrytes.io
 
 # Development URLs (for local development)
 # NEXT_PUBLIC_API_URL=http://localhost:3030
 # NEXT_PUBLIC_APP_URL=http://localhost:3000
 # NEXT_PUBLIC_INDEXER_URL=http://localhost:42069
+# NEXT_PUBLIC_DERIBIT_AGENT_URL=http://localhost:3031
+
+# Deribit Agent (auth via wrytes-api JWT — no API key needed)
 
 # Web3 Configuration
 NEXT_PUBLIC_REOWN_PROJECT_ID=...
 NEXT_PUBLIC_RPC_URL=...
-
-# Morpho Configuration
-NEXT_PUBLIC_MORPHO_GRAPHQL_ENDPOINT=...
-NEXT_PUBLIC_MORPHO_API_KEY=...

--- a/components/ui/CellEditable.tsx
+++ b/components/ui/CellEditable.tsx
@@ -1,0 +1,83 @@
+import { useState, useRef, useEffect } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPencil } from '@fortawesome/free-solid-svg-icons';
+
+interface CellEditableProps {
+  value: string;
+  onSave: (value: string) => Promise<void>;
+  placeholder?: string;
+  emptyPlaceholder?: string;
+  className?: string;
+}
+
+export function CellEditable({
+  value,
+  onSave,
+  placeholder = 'Click to edit',
+  emptyPlaceholder = '—',
+  className = '',
+}: CellEditableProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      setDraft(value);
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing, value]);
+
+  const save = async () => {
+    const trimmed = draft.trim();
+    if (trimmed === value) { setEditing(false); return; }
+    if (!trimmed) { setDraft(value); setEditing(false); return; }
+    setSaving(true);
+    try {
+      await onSave(trimmed);
+      setEditing(false);
+    } catch {
+      setDraft(value);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        value={draft}
+        onChange={e => setDraft(e.target.value)}
+        onBlur={save}
+        onKeyDown={e => {
+          if (e.key === 'Enter') { e.preventDefault(); save(); }
+          if (e.key === 'Escape') { setDraft(value); setEditing(false); }
+        }}
+        disabled={saving}
+        placeholder={placeholder}
+        className={`w-full min-w-[8rem] px-2 py-0.5 rounded border border-brand text-sm font-medium text-text-primary bg-card outline-none focus:ring-1 focus:ring-brand disabled:opacity-50 ${className}`}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      title="Click to edit"
+      className={`group flex items-center gap-1.5 text-left hover:text-brand transition-colors ${className}`}
+    >
+      <span className={value ? 'font-medium text-text-primary' : 'text-text-muted italic'}>
+        {value || emptyPlaceholder}
+      </span>
+      <FontAwesomeIcon
+        icon={faPencil}
+        className="w-2.5 h-2.5 text-text-muted opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+      />
+    </button>
+  );
+}

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -132,8 +132,12 @@ export interface AgentAction {
   pnlBtc?: number | null;
   /** Fee paid in BTC. Present on open and close events; 0 on settlement_expired; null on marks. */
   feeBtc?: number | null;
-  /** Daily time decay in BTC per unit (negative value — option loses this much per day). Present on open and settlement_unrealized. */
+  /** Daily time decay in BTC per unit (negative). Present on open and settlement_unrealized. */
   thetaBtc?: number | null;
+  /** Gross BTC in (open) or out (close/expired) before fees. Null on marks and init. */
+  cashflowBtc?: number | null;
+  /** margin − Σ(mktPrem × size for open positions) at event time. The true economic value. */
+  equityBtc?: number | null;
   marginBalanceBtc?: number;
   reason?: string;
 }

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -96,6 +96,25 @@ export type RunStatus = 'ACTIVE' | 'PAUSED' | 'STOPPED' | 'COMPLETED' | 'ERROR';
 export type RunType = 'BACKTEST' | 'PAPER' | 'LIVE';
 export type SessionStatus = 'QUEUED' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
 
+export interface ExecutionSettings {
+  dataFrom?: string;
+  dataTo?: string;
+  allowed_actions?: number[];
+  max_drawdown_limit?: number;
+  aggression_level?: number;
+  position_size_pct?: number;
+  max_position_btc?: number;
+  min_order_size?: number;
+  expiry_days_min?: number;
+  expiry_days_max?: number;
+  roll_dte_threshold?: number;
+  max_margin_ratio?: number;
+  delta_threshold?: number;
+  delta_penalty_coef?: number;
+  risk_free_rate?: number;
+  fast_margin?: boolean;
+}
+
 export interface AgentRun {
   id: string;
   name: string;
@@ -108,6 +127,7 @@ export interface AgentRun {
   realizedPnlBtc?: number;
   notes?: string;
   sessionId?: string;
+  executionSettings?: ExecutionSettings;
   createdAt: string;
   updatedAt: string;
 }
@@ -156,7 +176,7 @@ export interface TrainingSession {
   updatedAt: string;
   model?: { id: string; name: string } | null;
   hyperparams?: {
-    env?: Record<string, unknown>;
+    env?: ExecutionSettings & Record<string, unknown>;
     training?: Record<string, unknown>;
   };
 }
@@ -224,24 +244,6 @@ export interface CreateRunBody {
 export interface ExecuteRunBody {
   dataFrom?: string;
   dataTo?: string;
-  envOverrides?: {
-    // Conditioning inputs (set at inference time)
-    max_drawdown_limit?: number;
-    aggression_level?: number;
-    allowed_actions?: string[];
-    randomize_conditioning?: boolean;
-    // Core env params
-    expiry_days?: number;
-    position_size_pct?: number;
-    max_position_btc?: number;
-    delta_threshold?: number;
-    delta_penalty_coef?: number;
-    max_margin_ratio?: number;
-    risk_free_rate?: number;
-    loss_multiplier?: number;
-    loss_threshold?: number;
-    capital_eff_bonus?: number;
-  };
 }
 
 export interface RiskProfile {
@@ -257,7 +259,11 @@ export interface CreateSessionBody {
   dataTo: string;
   resolution?: string;
   algorithm?: string;
-  allowedStrategies?: string[];
+  allowedStrategies?: string[];  // legacy
+  allowedActions?: number[];
+  expiryDaysMin?: number;
+  expiryDaysMax?: number;
+  rollDteThreshold?: number;
   riskProfile?: RiskProfile;
   hyperparams?: Record<string, any>;
 }

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -104,6 +104,8 @@ export interface AgentRun {
   runType: RunType;
   deribitAccountId?: string;
   initialCapitalBtc: number;
+  currentCapitalBtc?: number;
+  realizedPnlBtc?: number;
   notes?: string;
   sessionId?: string;
   createdAt: string;
@@ -121,6 +123,7 @@ export interface AgentAction {
   delta?: number;
   ivRank?: number;
   pnlBtc?: number;
+  marginBalanceBtc?: number;
   reason?: string;
 }
 
@@ -136,6 +139,11 @@ export interface TrainingSession {
   resolution: string;
   createdAt: string;
   updatedAt: string;
+  model?: { id: string; name: string } | null;
+  hyperparams?: {
+    env?: Record<string, unknown>;
+    training?: Record<string, unknown>;
+  };
 }
 
 export interface TrainedModel {

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -170,7 +170,7 @@ export interface TrainedModel {
   winRate?: number;
   metadata?: Partial<ModelManifest>;
   createdAt: string;
-  session?: { name: string; algorithm: string; currency: string };
+  session?: { name: string; algorithm: string; currency: string; totalTimesteps?: number | null };
 }
 
 export interface DeribitAccount {

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -118,11 +118,22 @@ export interface AgentAction {
   timestamp: string;
   instrument?: string;
   quantity?: number;
+  /** Semantic varies by actionType: premium BTC/unit (open), current mark (settlement_unrealized), intrinsic (settlement_expired), buyback cost (close) */
   price?: number;
+  /** Original premium BTC/unit received when opening — present on settlement_unrealized, settlement_expired, close */
+  executedPrice?: number;
   btcPrice?: number;
   delta?: number;
   ivRank?: number;
-  pnlBtc?: number;
+  /**
+   * Lifetime realized P&L in BTC for settlement_expired and close events.
+   * Null for open (premium offsets obligation; no P&L yet) and settlement_unrealized.
+   */
+  pnlBtc?: number | null;
+  /** Fee paid in BTC. Present on open and close events; 0 on settlement_expired; null on marks. */
+  feeBtc?: number | null;
+  /** Daily time decay in BTC per unit (negative value — option loses this much per day). Present on open and settlement_unrealized. */
+  thetaBtc?: number | null;
   marginBalanceBtc?: number;
   reason?: string;
 }

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -146,6 +146,16 @@ export interface TrainingSession {
   };
 }
 
+export interface ModelManifest {
+  obs_version:  string;
+  obs_dims:     number;
+  obs_features: string[];
+  action_dims:  number;
+  data_columns: string[];
+  env_version:  string;
+  policy:       string;
+}
+
 export interface TrainedModel {
   id: string;
   name: string;
@@ -158,6 +168,7 @@ export interface TrainedModel {
   sharpeRatio?: number;
   maxDrawdown?: number;
   winRate?: number;
+  metadata?: Partial<ModelManifest>;
   createdAt: string;
   session?: { name: string; algorithm: string; currency: string };
 }
@@ -199,6 +210,12 @@ export interface ExecuteRunBody {
   dataFrom?: string;
   dataTo?: string;
   envOverrides?: {
+    // Conditioning inputs (set at inference time)
+    max_drawdown_limit?: number;
+    aggression_level?: number;
+    allowed_actions?: string[];
+    randomize_conditioning?: boolean;
+    // Core env params
     expiry_days?: number;
     position_size_pct?: number;
     max_position_btc?: number;
@@ -227,6 +244,7 @@ export interface CreateSessionBody {
   algorithm?: string;
   allowedStrategies?: string[];
   riskProfile?: RiskProfile;
+  hyperparams?: Record<string, any>;
 }
 
 export interface CreateAccountBody {

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { AuthStorage } from '../auth/storage';
 
 // Strip any accidental path/key from the base URL — only the origin is used.
 function parseOrigin(raw: string): string {
@@ -11,17 +12,18 @@ function parseOrigin(raw: string): string {
 }
 
 const BASE = parseOrigin(process.env.NEXT_PUBLIC_DERIBIT_AGENT_URL ?? '');
-const KEY = process.env.NEXT_PUBLIC_DERIBIT_AGENT_API_KEY ?? '';
 
 export async function agentFetch<T>(path: string, init?: RequestInit): Promise<T> {
   if (!BASE) throw new Error('NEXT_PUBLIC_DERIBIT_AGENT_URL is not configured.');
-  if (!KEY) throw new Error('NEXT_PUBLIC_DERIBIT_AGENT_API_KEY is not configured.');
+
+  const token = AuthStorage.getToken();
+  if (!token) throw new Error('Not authenticated — please sign in.');
 
   const res = await fetch(`${BASE}${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
-      'X-API-Key': KEY,          // ← header auth, as required by api-key.guard.ts
+      'Authorization': `Bearer ${token}`,
       ...(init?.headers ?? {}),
     },
   });

--- a/lib/deribit-agent/client.ts
+++ b/lib/deribit-agent/client.ts
@@ -254,7 +254,7 @@ export interface RiskProfile {
 export interface CreateSessionBody {
   name: string;
   description?: string;
-  currency: string;
+  currency?: string;             // optional when resumeFromModelId is set
   dataFrom: string;
   dataTo: string;
   resolution?: string;
@@ -266,6 +266,7 @@ export interface CreateSessionBody {
   rollDteThreshold?: number;
   riskProfile?: RiskProfile;
   hyperparams?: Record<string, any>;
+  resumeFromModelId?: string;
 }
 
 export interface CreateAccountBody {

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -600,7 +600,7 @@ export default function RunDetailPage() {
       const cat = optionCategory(a);
       if (cat) optCnt[cat] = (optCnt[cat] || 0) + 1;
     });
-    const pieL = OPTION_CATEGORIES.filter(k => (optCnt[k] ?? 0) > 0);
+    const pieL = OPTION_CATEGORIES.filter(k => (optCnt[k] ?? 0) > 0).sort((a, b) => optCnt[b] - optCnt[a]);
     const el7 = document.getElementById('c-pie') as HTMLCanvasElement | null;
     if (el7) {
       chartsRef.current['c-pie'] = new ChartJS<'doughnut'>(el7, {
@@ -665,14 +665,14 @@ export default function RunDetailPage() {
   const lastBtc = yearActions.length ? Number(yearActions[yearActions.length - 1].btcPrice) || 0 : 0;
   const finalEq = openingBalance + totalPnl;
 
-  // option-type breakdown
+  // option-type breakdown — net cash flow (cashflowBtc − feeBtc) per category
   const optionSummary: Record<string, { count: number; total: number }> = {};
   yearActions.forEach(a => {
     const cat = optionCategory(a);
     if (!cat) return;
     if (!optionSummary[cat]) optionSummary[cat] = { count: 0, total: 0 };
     optionSummary[cat].count++;
-    optionSummary[cat].total += Number(a.pnlBtc) || 0;
+    optionSummary[cat].total += (Number(a.cashflowBtc) || 0) - (Number(a.feeBtc) || 0);
   });
 
   // equity and cashflowBtc are computed by run_session.py and stored in the DB.
@@ -1111,12 +1111,12 @@ export default function RunDetailPage() {
                     <tr className="border-b border-surface">
                       <th className="text-left text-text-muted font-medium py-2">Category</th>
                       <th className="text-right text-text-muted font-medium py-2">Count</th>
-                      <th className="text-right text-text-muted font-medium py-2">Total (₿)</th>
+                      <th className="text-right text-text-muted font-medium py-2">Net CF (₿)</th>
                       <th className="text-right text-text-muted font-medium py-2">Avg (₿)</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {OPTION_CATEGORIES.map(cat => {
+                    {[...OPTION_CATEGORIES].sort((a, b) => (optionSummary[b]?.count ?? 0) - (optionSummary[a]?.count ?? 0)).map(cat => {
                       const s = optionSummary[cat] ?? { count: 0, total: 0 };
                       const avg = s.count ? s.total / s.count : 0;
                       const style = OPTION_BADGE[cat];

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -215,7 +215,7 @@ function sortActions(raw: AgentAction[]): AgentAction[] {
   return [...raw].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 }
 
-const COMMON_LINE = { pointRadius: 0, borderWidth: 1.5, tension: 0.3 };
+const COMMON_LINE = { pointRadius: 0, borderWidth: 1.5, tension: 0.3, spanGaps: true };
 
 // ─── Chart canvas wrapper ─────────────────────────────────────────────────────
 
@@ -287,20 +287,23 @@ export default function RunDetailPage() {
   }, [run.data]);
 
   // Debounce-save execForm to DB
+  const flushSettings = useCallback(async (form: ReturnType<typeof mkBlankExec>) => {
+    if (!runId) return;
+    await agentFetch(`/agent/runs/${runId}/settings`, {
+      method: 'PATCH',
+      body: JSON.stringify(form),
+    });
+    setSettingsSaved(true);
+    setTimeout(() => setSettingsSaved(false), 1500);
+  }, [runId]);
+
   const saveSettings = useCallback((form: ReturnType<typeof mkBlankExec>) => {
     if (!runId || !execFormLoaded.current) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(async () => {
-      try {
-        await agentFetch(`/agent/runs/${runId}/settings`, {
-          method: 'PATCH',
-          body: JSON.stringify(form),
-        });
-        setSettingsSaved(true);
-        setTimeout(() => setSettingsSaved(false), 1500);
-      } catch {}
+    debounceRef.current = setTimeout(() => {
+      flushSettings(form).catch(() => {});
     }, 800);
-  }, [runId]);
+  }, [runId, flushSettings]);
 
   useEffect(() => {
     if (!execFormLoaded.current) return;
@@ -323,6 +326,13 @@ export default function RunDetailPage() {
     }
     setExecuting(true);
     try {
+      // Cancel pending debounce and flush settings synchronously before execute
+      // so the server always reads the latest form values from the DB.
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      await flushSettings(execForm);
       await agentFetch(`/agent/runs/${runId}/execute`, {
         method: 'POST',
         body: JSON.stringify({
@@ -408,18 +418,23 @@ export default function RunDetailPage() {
 
     const callStrike: (number | null)[] = [];
     const putStrike: (number | null)[] = [];
-    let cK: number | null = null,
-      pK: number | null = null;
+    // Track by instrument name so open/close are matched exactly.
+    // Avoids false retentions when a close event has a null/mismatched instrument.
+    const openPos = new Map<string, { strike: number; type: 'call' | 'put' }>();
     actions.forEach(a => {
-      const t = a.actionType;
-      const opt = instrOptType(a.instrument);
-      const k   = instrStrike(a.instrument);
-      if (t === 'open') {
-        if (opt === 'call') cK = k;
-        if (opt === 'put')  pK = k;
+      const t     = a.actionType;
+      const instr = a.instrument ?? '';
+      const opt   = instrOptType(a.instrument);
+      const k     = instrStrike(a.instrument);
+      if (t === 'open' && opt && k !== null) {
+        openPos.set(instr, { strike: k, type: opt });
       } else if (t === 'close' || t === 'settlement_expired') {
-        if (opt === 'call') cK = null;
-        if (opt === 'put')  pK = null;
+        openPos.delete(instr);
+      }
+      let cK: number | null = null, pK: number | null = null;
+      for (const pos of openPos.values()) {
+        if (pos.type === 'call') cK = pos.strike;
+        if (pos.type === 'put')  pK = pos.strike;
       }
       callStrike.push(cK);
       putStrike.push(pK);
@@ -501,6 +516,7 @@ export default function RunDetailPage() {
             data: callStrike,
             borderColor: '#4e8ef7',
             stepped: true,
+            spanGaps: false,
           },
           {
             ...COMMON_LINE,
@@ -508,6 +524,7 @@ export default function RunDetailPage() {
             data: putStrike,
             borderColor: '#ef4444',
             stepped: true,
+            spanGaps: false,
           },
         ],
       },

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -167,6 +167,7 @@ const ACTION_BADGE: Record<string, { color: string; bg: string; label: string }>
   settlement_expired:    { color: 'text-amber-600',  bg: 'bg-amber-100/80',  label: 'Expired'  },
   open:                  { color: 'text-success',    bg: 'bg-success/10',    label: 'Open'     },
   close:                 { color: 'text-error',      bg: 'bg-error/10',      label: 'Close'    },
+  hold:                  { color: 'text-slate-400',  bg: 'bg-slate-100/40',  label: 'Hold'     },
 };
 
 const OPTION_CATEGORIES = [
@@ -385,18 +386,21 @@ export default function RunDetailPage() {
     const initCap = openingBalance ?? Number(runData.initialCapitalBtc);
     const labels = actions.map(a => fmtDate(a.timestamp));
 
+    // Use stored equityBtc (computed by run_session.py) for precise P&L tracking against
+    // openingBalance. Falls back to cumulative pnlBtc sum only for actions missing equityBtc.
     let cum = 0;
-    const cumPnlBtc = actions.map(a => {
+    const cumPnlBtc: (number | null)[] = actions.map(a => {
+      if (a.equityBtc != null) return +(Number(a.equityBtc) - initCap).toFixed(6);
       cum += Number(a.pnlBtc) || 0;
       return +cum.toFixed(6);
     });
-    const equityBtc = cumPnlBtc.map(c => +(initCap + c).toFixed(6));
+    const equityBtc = cumPnlBtc.map(c => c != null ? +(initCap + c).toFixed(6) : null);
     const btcPrice = actions.map(a => (a.btcPrice != null ? Number(a.btcPrice) : null));
     const equityUsd = equityBtc.map((e, i) =>
-      btcPrice[i] != null ? +(e * btcPrice[i]!).toFixed(0) : null
+      e != null && btcPrice[i] != null ? +(e * btcPrice[i]!).toFixed(0) : null
     );
     const cumPnlUsd = cumPnlBtc.map((p, i) =>
-      btcPrice[i] != null ? +(p * btcPrice[i]!).toFixed(0) : null
+      p != null && btcPrice[i] != null ? +(p * btcPrice[i]!).toFixed(0) : null
     );
     const rewardBar = actions.map(a => Number(a.pnlBtc) || 0);
     const ivData = actions.map(a => (a.ivRank != null ? Number(a.ivRank) : null));
@@ -681,13 +685,29 @@ export default function RunDetailPage() {
     optionSummary[cat].total += (Number(a.cashflowBtc) || 0) - (Number(a.feeBtc) || 0);
   });
 
-  // equity and cashflowBtc are computed by run_session.py and stored in the DB.
-  // The app only needs to derive cumPnl = equity − openingBalance.
+  // equity and cashflowBtc are computed by run_session.py and stored in the DB as absolute
+  // values — no offset needed. prevEpochLast seeds the synthetic Init row so it shows the
+  // actual closing state of the prior epoch rather than the computed openingBalance.
+  const prevEpochLast = (() => {
+    if (!yearFilter) return null;
+    const prev = actions.filter(
+      a => new Date(a.timestamp).getFullYear() < parseInt(yearFilter) && a.actionType !== 'settlement_init'
+    );
+    if (!prev.length) return null;
+    const last = prev[prev.length - 1];
+    const equity = last.equityBtc != null
+      ? Number(last.equityBtc)
+      : (last.marginBalanceBtc != null ? Number(last.marginBalanceBtc) : null);
+    const margin = last.marginBalanceBtc != null ? Number(last.marginBalanceBtc) : equity;
+    return { equity, margin };
+  })();
+
   const actionLog = (() => {
     return yearActions.map(a => {
-      const equity = a.equityBtc != null ? Number(a.equityBtc) : (a.marginBalanceBtc != null ? Number(a.marginBalanceBtc) : 0);
+      const marginBalance = a.marginBalanceBtc != null ? Number(a.marginBalanceBtc) : null;
+      const equity = a.equityBtc != null ? Number(a.equityBtc) : (marginBalance ?? 0);
       const cumPnl = equity - openingBalance;
-      return { ...a, equity, cumPnl };
+      return { ...a, equity, cumPnl, marginBalance };
     });
   })();
 
@@ -701,7 +721,7 @@ export default function RunDetailPage() {
   // filtered log (newest first) — year already scoped via yearActions
   // settlement_init is always represented by the pinned opening-balance row, so exclude it here
   const filteredLog = [...actionLog].filter(a => {
-    if (a.actionType === 'settlement_init') return false;
+    if (a.actionType === 'settlement_init' || a.actionType === 'hold') return false;
     if (logTypeFilter && a.actionType !== logTypeFilter) return false;
     if (logSearch) {
       const q = logSearch.toLowerCase();
@@ -1322,8 +1342,8 @@ export default function RunDetailPage() {
                           <td className="px-3 py-1.5 text-right">{dash}</td>
                           <td className="px-3 py-1.5 text-right">{dash}</td>
                           <td className="px-3 py-1.5 text-right font-mono text-text-muted">{n(0)}</td>
-                          <td className="px-3 py-1.5 text-right font-mono">{n(openingBalance, 4)}</td>
-                          <td className="px-3 py-1.5 text-right font-mono">{n(openingBalance, 4)}</td>
+                          <td className="px-3 py-1.5 text-right font-mono">{n(prevEpochLast?.margin ?? openingBalance, 4)}</td>
+                          <td className="px-3 py-1.5 text-right font-mono">{n(prevEpochLast?.equity ?? openingBalance, 4)}</td>
                         </tr>
                       );
                     })()}
@@ -1413,7 +1433,7 @@ export default function RunDetailPage() {
                           </td>
                           {/* Margin */}
                           <td className="px-3 py-1.5 text-right font-mono">
-                            {a.marginBalanceBtc != null ? n(a.marginBalanceBtc, 4) : '—'}
+                            {a.marginBalance != null ? n(a.marginBalance, 4) : '—'}
                           </td>
                           {/* Equity */}
                           <td className="px-3 py-1.5 text-right font-mono">

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -219,13 +219,21 @@ export default function RunDetailPage() {
 
   const chartsRef = useRef<Record<string, ChartJS>>({});
   const [chartsReady, setChartsReady] = useState(false);
+  const [yearFilter, setYearFilter] = useState('');
   const [logTypeFilter, setLogTypeFilter] = useState('');
   const [logSearch, setLogSearch] = useState('');
 
   // Execution accordion
   const [showExec, setShowExec] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [execForm, setExecForm] = useState(mkBlankExec);
+  const [execForm, setExecForm] = useState<ReturnType<typeof mkBlankExec>>(() => {
+    if (typeof window === 'undefined') return mkBlankExec();
+    try {
+      const saved = localStorage.getItem('deribit:exec-settings');
+      if (saved) return { ...mkBlankExec(), ...JSON.parse(saved) };
+    } catch {}
+    return mkBlankExec();
+  });
   const [executing, setExecuting] = useState(false);
   const [actioning, setActioning] = useState(false);
 
@@ -302,21 +310,32 @@ export default function RunDetailPage() {
   };
 
   useEffect(() => {
-    if (!run.data || !actionsReq.data) return;
+    try { localStorage.setItem('deribit:exec-settings', JSON.stringify(execForm)); } catch {}
+  }, [execForm]);
 
-    // slight delay so canvas elements are mounted
+  useEffect(() => {
+    if (!run.data || !actionsReq.data) return;
+    const allActions = [...actionsReq.data].reverse();
+    const filtered = yearFilter
+      ? allActions.filter(a => new Date(a.timestamp).getFullYear().toString() === yearFilter)
+      : allActions;
+    const opening = yearFilter
+      ? Number(run.data.initialCapitalBtc) + allActions
+          .filter(a => new Date(a.timestamp).getFullYear() < parseInt(yearFilter))
+          .reduce((s, a) => s + (Number(a.pnlBtc) || 0), 0)
+      : Number(run.data.initialCapitalBtc);
     const t = setTimeout(() => {
       destroyCharts();
-      buildCharts(run.data!, [...actionsReq.data!].reverse());
+      buildCharts(run.data!, filtered, opening);
       setChartsReady(true);
     }, 50);
     return () => clearTimeout(t);
-  }, [run.data, actionsReq.data]);
+  }, [run.data, actionsReq.data, yearFilter]);
 
   useEffect(() => () => destroyCharts(), []);
 
-  function buildCharts(runData: RunDetail, actions: AgentAction[]) {
-    const initCap = Number(runData.initialCapitalBtc);
+  function buildCharts(runData: RunDetail, actions: AgentAction[], openingBalance?: number) {
+    const initCap = openingBalance ?? Number(runData.initialCapitalBtc);
     const labels = actions.map(a => fmtDate(a.timestamp));
 
     let cum = 0;
@@ -610,20 +629,37 @@ export default function RunDetailPage() {
   const actions = actionsReq.data ? [...actionsReq.data].reverse() : [];
   const runData = run.data;
   const initCap = runData ? Number(runData.initialCapitalBtc) : 0;
-  const tradeActions = actions.filter(a => a.actionType !== 'hold');
+
+  // All years available from the full dataset (for tab list)
+  const uniqueYears = Array.from(
+    new Set(actions.map(a => new Date(a.timestamp).getFullYear().toString()))
+  ).sort();
+
+  // Accounting carry-over: opening balance = prior year(s) cumulative equity
+  const openingBalance = yearFilter
+    ? initCap + actions
+        .filter(a => new Date(a.timestamp).getFullYear() < parseInt(yearFilter))
+        .reduce((s, a) => s + (Number(a.pnlBtc) || 0), 0)
+    : initCap;
+
+  // All page content scoped to selected year
+  const yearActions = yearFilter
+    ? actions.filter(a => new Date(a.timestamp).getFullYear().toString() === yearFilter)
+    : actions;
+
+  const tradeActions = yearActions.filter(a => a.actionType !== 'hold');
   const tradePnls = tradeActions.map(a => Number(a.pnlBtc) || 0);
-  // Total P&L includes hold rows — they now carry real unrealized equity changes
-  const totalPnl = actions.reduce((s, a) => s + (Number(a.pnlBtc) || 0), 0);
+  const totalPnl = yearActions.reduce((s, a) => s + (Number(a.pnlBtc) || 0), 0);
   const wins = tradePnls.filter(v => v > 0).length;
   const winRate = tradeActions.length ? (wins / tradeActions.length) * 100 : 0;
   const best = tradePnls.length ? Math.max(...tradePnls) : 0;
   const worst = tradePnls.length ? Math.min(...tradePnls) : 0;
-  const lastBtc = actions.length ? Number(actions[actions.length - 1].btcPrice) || 0 : 0;
-  const finalEq = initCap + totalPnl;
+  const lastBtc = yearActions.length ? Number(yearActions[yearActions.length - 1].btcPrice) || 0 : 0;
+  const finalEq = openingBalance + totalPnl;
 
   // type breakdown
   const typeSummary: Record<string, { count: number; total: number }> = {};
-  actions.forEach(a => {
+  yearActions.forEach(a => {
     if (!typeSummary[a.actionType]) typeSummary[a.actionType] = { count: 0, total: 0 };
     typeSummary[a.actionType].count++;
     typeSummary[a.actionType].total += Number(a.pnlBtc) || 0;
@@ -639,7 +675,7 @@ export default function RunDetailPage() {
     let openPutStrike: number | null = null;
     let openCallStrike: number | null = null;
 
-    return actions.map(a => {
+    return yearActions.map(a => {
       c += Number(a.pnlBtc) || 0;
       const legs = parseLegs(a.instrument);
       const qty = a.quantity != null ? Number(a.quantity) : null;
@@ -667,16 +703,16 @@ export default function RunDetailPage() {
       }
 
       return {
-        ...a, cumPnl: c, equity: initCap + c,
+        ...a, cumPnl: c, equity: openingBalance + c,
         openPut, openCall, openPutSize, openCallSize, openPutStrike, openCallStrike,
       };
     });
   })();
 
-  // unique action types for filter chips (stable order)
-  const uniqueTypes = Array.from(new Set(actions.map(a => a.actionType)));
+  // unique action types within selected year
+  const uniqueTypes = Array.from(new Set(yearActions.map(a => a.actionType)));
 
-  // filtered + reversed log (newest first)
+  // filtered log (newest first) — year already scoped via yearActions
   const filteredLog = [...actionLog].filter(a => {
     if (logTypeFilter && a.actionType !== logTypeFilter) return false;
     if (logSearch) {
@@ -1047,7 +1083,7 @@ export default function RunDetailPage() {
                 },
                 { label: 'Best Trade', value: `${n(best)} ₿`, cls: 'text-success' },
                 { label: 'Worst Trade', value: `${n(worst)} ₿`, cls: 'text-error' },
-                { label: 'Capital', value: `${n(initCap, 4)} ₿`, cls: '' },
+                { label: yearFilter ? 'Begin Equity' : 'Capital', value: `${n(yearFilter ? openingBalance : initCap, 4)} ₿`, cls: '' },
               ].map(s => (
                 <Card key={s.label} className="flex flex-col gap-1">
                   <span className="text-text-muted text-xs uppercase tracking-wide">{s.label}</span>
@@ -1056,6 +1092,26 @@ export default function RunDetailPage() {
                 </Card>
               ))}
             </div>
+
+            {/* Year filter tabs */}
+            {uniqueYears.length > 1 && (
+              <div className="mt-6 flex items-center gap-1 border-b border-surface pb-1">
+                {['All', ...uniqueYears].map(y => (
+                  <button
+                    key={y}
+                    type="button"
+                    onClick={() => setYearFilter(y === 'All' ? '' : y)}
+                    className={`px-3 py-1.5 rounded-t text-xs font-semibold transition-colors ${
+                      (y === 'All' ? !yearFilter : yearFilter === y)
+                        ? 'text-brand border-b-2 border-brand -mb-px'
+                        : 'text-text-muted hover:text-text-primary'
+                    }`}
+                  >
+                    {y}
+                  </button>
+                ))}
+              </div>
+            )}
 
             {/* Primary charts */}
             <div className="mt-6 space-y-4">

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -122,65 +122,62 @@ function fmtShort(ts: string | number) {
   });
 }
 
-function sizedInstrument(
-  instrument: string,
-  qty: number | null | undefined,
-  actionType: string
-): string {
-  if (qty == null) return instrument;
-  const sign = actionType.startsWith('sell_') ? -1 : 1;
-  const sized = (sign * Number(qty)).toFixed(1);
-  return `${sized} ${instrument}`;
+function instrOptType(instrument?: string | null): 'call' | 'put' | null {
+  if (!instrument) return null;
+  const s = instrument.split('-').pop()?.toUpperCase();
+  return s === 'C' ? 'call' : s === 'P' ? 'put' : null;
 }
 
-function parseLegs(instrument?: string | null) {
-  const empty = {
-    call: null as number | null, put: null as number | null,
-    callInstrument: null as string | null, putInstrument: null as string | null,
-    callSize: null as number | null, putSize: null as number | null,
-  };
-  if (!instrument) return empty;
-  let call: number | null = null, put: number | null = null;
-  let callInstrument: string | null = null, putInstrument: string | null = null;
-  let callSize: number | null = null, putSize: number | null = null;
-  instrument.split('|').forEach(leg => {
-    // Support size-prefixed format: "0.4:BTC-07FEB25-105000-C"
-    let name = leg, size: number | null = null;
-    const colon = leg.indexOf(':');
-    if (colon > 0) {
-      const s = parseFloat(leg.slice(0, colon));
-      if (!isNaN(s)) { size = s; name = leg.slice(colon + 1); }
-    }
-    const p = name.split('-');
-    if (p.length < 4) return;
-    const k = Number(p[2]), t = p[3].toUpperCase();
-    if (t === 'C') { call = k; callInstrument = name; callSize = size; }
-    else if (t === 'P') { put = k; putInstrument = name; putSize = size; }
-  });
-  return { call, put, callInstrument, putInstrument, callSize, putSize };
+function instrStrike(instrument?: string | null): number | null {
+  if (!instrument) return null;
+  const parts = instrument.split('-');
+  if (parts.length < 4) return null;
+  const k = Number(parts[parts.length - 2]);
+  return isNaN(k) ? null : k;
 }
 
 const ACTION_COLORS: Record<string, string> = {
-  sell_call: '#e6952c',
-  sell_put: '#0ea5e9',
-  sell_strangle: '#8b5cf6',
-  close: '#ef4444',
-  hold: '#94a3b8',
-  buy_call: '#22c55e',
-  buy_put: '#f43f5e',
-  hedge: '#f59e0b',
+  settlement_init:       '#64748b',
+  settlement_unrealized: '#0ea5e9',
+  settlement_expired:    '#f59e0b',
+  open:                  '#22c55e',
+  close:                 '#ef4444',
 };
 
-const ACTION_BADGE: Record<string, { color: string; bg: string }> = {
-  sell_call: { color: 'text-yellow-600', bg: 'bg-yellow-100/80' },
-  sell_put: { color: 'text-sky-600', bg: 'bg-sky-100/80' },
-  sell_strangle: { color: 'text-purple-600', bg: 'bg-purple-100/80' },
-  close: { color: 'text-error', bg: 'bg-error/10' },
-  hold: { color: 'text-text-muted', bg: 'bg-surface' },
-  buy_call: { color: 'text-success', bg: 'bg-success/10' },
-  buy_put: { color: 'text-rose-500', bg: 'bg-rose-100/80' },
-  hedge: { color: 'text-yellow-500', bg: 'bg-yellow-400/10' },
+const ACTION_BADGE: Record<string, { color: string; bg: string; label: string }> = {
+  settlement_init:       { color: 'text-slate-500',  bg: 'bg-slate-100/60',  label: 'Init'     },
+  settlement_unrealized: { color: 'text-sky-600',    bg: 'bg-sky-100/80',    label: 'Mark'     },
+  settlement_expired:    { color: 'text-amber-600',  bg: 'bg-amber-100/80',  label: 'Expired'  },
+  open:                  { color: 'text-success',    bg: 'bg-success/10',    label: 'Open'     },
+  close:                 { color: 'text-error',      bg: 'bg-error/10',      label: 'Close'    },
 };
+
+function cashflow(a: AgentAction): number | null {
+  const qty = a.quantity != null ? Number(a.quantity) : null;
+  const p   = a.price   != null ? Number(a.price)    : null;
+  if (qty == null || p == null) return null;
+  if (a.actionType === 'open')               return  p * qty;   // premium inflow
+  if (a.actionType === 'close')              return -(p * qty);  // buyback outflow
+  if (a.actionType === 'settlement_expired') return -(p * qty);  // settlement payout (0 if OTM)
+  return null;
+}
+
+// Within-day event order: settlement phase first, then trade actions
+const TYPE_ORDER: Record<string, number> = {
+  settlement_init:       0,
+  settlement_expired:    1,
+  settlement_unrealized: 2,
+  open:                  3,
+  close:                 4,
+};
+
+function sortActions(raw: AgentAction[]): AgentAction[] {
+  return [...raw].sort((a, b) => {
+    const dt = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    if (dt !== 0) return dt;
+    return (TYPE_ORDER[a.actionType] ?? 5) - (TYPE_ORDER[b.actionType] ?? 5);
+  });
+}
 
 const COMMON_LINE = { pointRadius: 0, borderWidth: 1.5, tension: 0.3 };
 
@@ -315,7 +312,7 @@ export default function RunDetailPage() {
 
   useEffect(() => {
     if (!run.data || !actionsReq.data) return;
-    const allActions = [...actionsReq.data].reverse();
+    const allActions = sortActions(actionsReq.data);
     const filtered = yearFilter
       ? allActions.filter(a => new Date(a.timestamp).getFullYear().toString() === yearFilter)
       : allActions;
@@ -360,18 +357,15 @@ export default function RunDetailPage() {
     let cK: number | null = null,
       pK: number | null = null;
     actions.forEach(a => {
-      const t = a.actionType,
-        legs = parseLegs(a.instrument);
-      if (t === 'sell_call') {
-        cK = legs.call;
-      } else if (t === 'sell_put') {
-        pK = legs.put;
-      } else if (t === 'sell_strangle') {
-        if (legs.call != null) cK = legs.call;
-        if (legs.put != null) pK = legs.put;
-      } else if (t === 'close') {
-        cK = null;
-        pK = null;
+      const t = a.actionType;
+      const opt = instrOptType(a.instrument);
+      const k   = instrStrike(a.instrument);
+      if (t === 'open') {
+        if (opt === 'call') cK = k;
+        if (opt === 'put')  pK = k;
+      } else if (t === 'close' || t === 'settlement_expired') {
+        if (opt === 'call') cK = null;
+        if (opt === 'put')  pK = null;
       }
       callStrike.push(cK);
       putStrike.push(pK);
@@ -626,7 +620,7 @@ export default function RunDetailPage() {
   }
 
   // ── Derived stats ────────────────────────────────────────────────────────────
-  const actions = actionsReq.data ? [...actionsReq.data].reverse() : [];
+  const actions = actionsReq.data ? sortActions(actionsReq.data) : [];
   const runData = run.data;
   const initCap = runData ? Number(runData.initialCapitalBtc) : 0;
 
@@ -647,7 +641,10 @@ export default function RunDetailPage() {
     ? actions.filter(a => new Date(a.timestamp).getFullYear().toString() === yearFilter)
     : actions;
 
-  const tradeActions = yearActions.filter(a => a.actionType !== 'hold');
+  // Only cash-flow events count as "trades" for stats
+  const tradeActions = yearActions.filter(
+    a => a.actionType === 'open' || a.actionType === 'close' || a.actionType === 'settlement_expired'
+  );
   const tradePnls = tradeActions.map(a => Number(a.pnlBtc) || 0);
   const totalPnl = yearActions.reduce((s, a) => s + (Number(a.pnlBtc) || 0), 0);
   const wins = tradePnls.filter(v => v > 0).length;
@@ -665,47 +662,37 @@ export default function RunDetailPage() {
     typeSummary[a.actionType].total += Number(a.pnlBtc) || 0;
   });
 
-  // cumulative pnl + running open-position state for the log table
+  // cumulative realized pnl + per-row equity
+  // equity = margin − Σ(mktPrem × size) for open positions
+  // mirrors the env: equity_btc = margin_balance + unrealized_btc, where unrealized_btc = −liability
   const actionLog = (() => {
-    let c = 0;
-    let openPut: string | null = null;
-    let openCall: string | null = null;
-    let openPutSize: number | null = null;
-    let openCallSize: number | null = null;
-    let openPutStrike: number | null = null;
-    let openCallStrike: number | null = null;
+    let realizedPnl = 0; // used only as fallback when marginBalanceBtc is missing
+    const openPos = new Map<string, { size: number; mktPrem: number }>();
 
     return yearActions.map(a => {
-      c += Number(a.pnlBtc) || 0;
-      const legs = parseLegs(a.instrument);
-      const qty = a.quantity != null ? Number(a.quantity) : null;
-      const t = a.actionType;
+      realizedPnl += Number(a.pnlBtc) || 0;
 
-      if (t === 'sell_put') {
-        openPut = legs.putInstrument;
-        openPutStrike = legs.put;
-        openPutSize = -(legs.putSize ?? qty ?? 0);
-      } else if (t === 'sell_call') {
-        openCall = legs.callInstrument;
-        openCallStrike = legs.call;
-        openCallSize = -(legs.callSize ?? qty ?? 0);
-      } else if (t === 'sell_strangle') {
-        openPut = legs.putInstrument;
-        openCall = legs.callInstrument;
-        openPutStrike = legs.put;
-        openCallStrike = legs.call;
-        openPutSize = -(legs.putSize ?? qty ?? 0);
-        openCallSize = -(legs.callSize ?? qty ?? 0);
-      } else if (t === 'close' || t.startsWith('close_')) {
-        openPut = null; openCall = null;
-        openPutSize = null; openCallSize = null;
-        openPutStrike = null; openCallStrike = null;
+      const instr = a.instrument ?? '';
+      const qty   = a.quantity != null ? Number(a.quantity) : 0;
+      const price = a.price    != null ? Number(a.price)    : 0;
+
+      if (a.actionType === 'open') {
+        openPos.set(instr, { size: qty, mktPrem: price });
+      } else if (a.actionType === 'settlement_unrealized') {
+        const existing = openPos.get(instr);
+        openPos.set(instr, { size: existing?.size ?? qty, mktPrem: price });
+      } else if (a.actionType === 'close' || a.actionType === 'settlement_expired') {
+        openPos.delete(instr);
       }
 
-      return {
-        ...a, cumPnl: c, equity: openingBalance + c,
-        openPut, openCall, openPutSize, openCallSize, openPutStrike, openCallStrike,
-      };
+      let totalLiability = 0;
+      for (const pos of openPos.values()) totalLiability += pos.mktPrem * pos.size;
+
+      const margin = a.marginBalanceBtc != null ? Number(a.marginBalanceBtc) : openingBalance + realizedPnl;
+      const equity = margin - totalLiability;
+      const cumPnl = equity - openingBalance; // total P&L = equity change from opening balance
+
+      return { ...a, cumPnl, equity };
     });
   })();
 
@@ -1144,15 +1131,12 @@ export default function RunDetailPage() {
                       .sort((a, b) => b[1].count - a[1].count)
                       .map(([type, s]) => {
                         const avg = s.total / s.count;
-                        const style = ACTION_BADGE[type] ?? {
-                          color: 'text-text-secondary',
-                          bg: 'bg-surface',
-                        };
+                        const style = ACTION_BADGE[type] ?? { color: 'text-text-secondary', bg: 'bg-surface', label: type };
                         return (
                           <tr key={type} className="border-b border-surface/50">
                             <td className="py-2">
                               <Badge
-                                text={type}
+                                text={style.label}
                                 variant="custom"
                                 customColor={style.color}
                                 customBgColor={style.bg}
@@ -1210,29 +1194,30 @@ export default function RunDetailPage() {
               </div>
 
               <div className="overflow-x-auto max-h-[520px] overflow-y-auto">
-                <table className="w-full text-xs min-w-[760px]">
+                <table className="w-full text-xs min-w-[900px]">
                   <thead className="sticky top-0 z-10 bg-card">
                     <tr className="border-b-2 border-surface">
                       {(
                         [
-                          ['Date', 'text-left'],
-                          ['Action', 'text-left'],
-                          ['Put', 'text-left'],
-                          ['BTC Price', 'text-right'],
-                          ['Call', 'text-left'],
-                          ['IV Rank', 'text-right'],
-                          ['Delta', 'text-right'],
-                          ['PnL (₿)', 'text-right'],
+                          ['Date',         'text-left'],
+                          ['Type',         'text-left'],
+                          ['Size',         'text-right'],
+                          ['Instrument',   'text-left'],
+                          ['BTC Price',    'text-right'],
+                          ['IV',           'text-right'],
+                          ['Δ',            'text-right'],
+                          ['Θ/day',        'text-right'],
+                          ['Orig Prem',    'text-right'],
+                          ['Mkt Prem',     'text-right'],
+                          ['Cashflow',     'text-right'],
+                          ['Fee (₿)',      'text-right'],
+                          ['PnL (₿)',      'text-right'],
                           ['Cum PnL (₿)', 'text-right'],
-                          ['Margin Bal (₿)', 'text-right'],
-                          ['Equity (₿)', 'text-right'],
-                          ['Equity (USD)', 'text-right'],
+                          ['Margin (₿)',  'text-right'],
+                          ['Equity (₿)',  'text-right'],
                         ] as const
                       ).map(([h, align]) => (
-                        <th
-                          key={h}
-                          className={`px-3 py-2 font-medium text-text-muted whitespace-nowrap ${align}`}
-                        >
+                        <th key={h} className={`px-3 py-2 font-medium text-text-muted whitespace-nowrap ${align}`}>
                           {h}
                         </th>
                       ))}
@@ -1240,65 +1225,103 @@ export default function RunDetailPage() {
                   </thead>
                   <tbody>
                     {filteredLog.map((a, i) => {
-                      const btcP = a.btcPrice != null ? Number(a.btcPrice) : null;
-                      const style = ACTION_BADGE[a.actionType] ?? {
-                        color: 'text-text-secondary',
-                        bg: 'bg-surface',
-                      };
+                      const btcP  = a.btcPrice != null ? Number(a.btcPrice) : null;
+                      const style = ACTION_BADGE[a.actionType] ?? { color: 'text-text-secondary', bg: 'bg-surface', label: a.actionType };
+                      const opt   = instrOptType(a.instrument);
+                      const k     = instrStrike(a.instrument);
+                      const itm   = opt === 'call'
+                        ? (btcP != null && k != null && k < btcP)
+                        : opt === 'put'
+                          ? (btcP != null && k != null && k > btcP)
+                          : false;
+
+                      // For open: price = original premium (executedPrice not set yet).
+                      // For mark/expired/close: executedPrice = original premium, price = current mark/intrinsic/buyback.
+                      // At open, mktPrem = origPrem (just sold at market → size×(orig−mkt) = 0).
+                      const isOpen   = a.actionType === 'open';
+                      const origPrem = isOpen ? a.price : a.executedPrice;
+                      const mktPrem  = isOpen ? a.price : a.price;   // open: same as orig; others: current mark
+
+                      // PnL: for unrealized marks, derive from size × (orig − mkt) since pnlBtc is null.
+                      // For open: size×(orig−mkt) = 0, which is intentional.
+                      const unrealPnl =
+                        a.pnlBtc == null && origPrem != null && mktPrem != null && a.quantity != null
+                          ? Number(a.quantity) * (Number(origPrem) - Number(mktPrem))
+                          : null;
+                      const displayPnl = a.pnlBtc ?? unrealPnl;
+
                       return (
                         <tr key={a.id ?? i} className={i % 2 === 0 ? '' : 'bg-surface/20'}>
+                          {/* Date */}
                           <td className="px-3 py-1.5 text-text-muted whitespace-nowrap">
                             {fmtShort(a.timestamp)}
                           </td>
+                          {/* Type */}
                           <td className="px-3 py-1.5">
-                            <Badge
-                              text={a.actionType}
-                              variant="custom"
-                              customColor={style.color}
-                              customBgColor={style.bg}
-                            />
+                            <Badge text={style.label} variant="custom" customColor={style.color} customBgColor={style.bg} />
                           </td>
-                          <td className={`px-3 py-1.5 text-left font-mono ${
-                            a.openPut && btcP && a.openPutStrike != null && a.openPutStrike > btcP
-                              ? 'text-error' : 'text-text-primary'
-                          }`}>
-                            {a.openPut && a.openPutSize != null
-                              ? `${a.openPutSize.toFixed(1)} ${a.openPut}`
-                              : '—'}
+                          {/* Size */}
+                          <td className="px-3 py-1.5 text-right font-mono text-text-primary">
+                            {a.quantity != null ? Number(a.quantity).toFixed(2) : '—'}
                           </td>
+                          {/* Instrument */}
+                          <td className={`px-3 py-1.5 font-mono whitespace-nowrap ${itm ? 'text-error font-semibold' : 'text-text-primary'}`}>
+                            {a.instrument ?? '—'}
+                          </td>
+                          {/* BTC Price */}
                           <td className="px-3 py-1.5 text-right text-text-primary font-mono">
-                            {btcP
-                              ? '$' + btcP.toLocaleString('en-US', { maximumFractionDigits: 0 })
-                              : '—'}
+                            {btcP ? '$' + btcP.toLocaleString('en-US', { maximumFractionDigits: 0 }) : '—'}
                           </td>
-                          <td className={`px-3 py-1.5 text-left font-mono ${
-                            a.openCall && btcP && a.openCallStrike != null && a.openCallStrike < btcP
-                              ? 'text-error' : 'text-text-primary'
-                          }`}>
-                            {a.openCall && a.openCallSize != null
-                              ? `${a.openCallSize.toFixed(1)} ${a.openCall}`
-                              : '—'}
-                          </td>
+                          {/* IV */}
                           <td className="px-3 py-1.5 text-right">
                             {a.ivRank != null ? Number(a.ivRank).toFixed(1) : '—'}
                           </td>
+                          {/* Delta */}
                           <td className="px-3 py-1.5 text-right">
                             {a.delta != null ? Number(a.delta).toFixed(3) : '—'}
                           </td>
-                          <td
-                            className={`px-3 py-1.5 text-right font-mono ${clsColor(Number(a.pnlBtc) || 0)}`}
-                          >
-                            {n(a.pnlBtc)}
+                          {/* Theta/day (negative = option decays; shown as-is) */}
+                          <td className="px-3 py-1.5 text-right font-mono text-text-muted">
+                            {a.thetaBtc != null ? n(a.thetaBtc, 6) : '—'}
                           </td>
+                          {/* Orig Prem */}
+                          <td className="px-3 py-1.5 text-right font-mono text-text-secondary">
+                            {origPrem != null ? n(origPrem, 6) : '—'}
+                          </td>
+                          {/* Mkt Prem */}
+                          <td className="px-3 py-1.5 text-right font-mono text-text-muted">
+                            {mktPrem != null ? n(mktPrem, 6) : '—'}
+                          </td>
+                          {/* Cashflow: actual BTC in (+) or out (−) */}
+                          {(() => {
+                            const cf = cashflow(a);
+                            return (
+                              <td className={`px-3 py-1.5 text-right font-mono ${cf != null ? clsColor(cf) : 'text-text-muted'}`}>
+                                {cf != null ? n(cf) : '—'}
+                              </td>
+                            );
+                          })()}
+                          {/* Fee — shown as negative (it's a cost) */}
+                          <td className="px-3 py-1.5 text-right font-mono text-error">
+                            {a.feeBtc != null && Number(a.feeBtc) !== 0
+                              ? '-' + n(Math.abs(Number(a.feeBtc)), 6)
+                              : '—'}
+                          </td>
+                          {/* PnL */}
+                          <td className={`px-3 py-1.5 text-right font-mono ${displayPnl != null ? clsColor(Number(displayPnl)) : 'text-text-muted'}`}>
+                            {displayPnl != null ? n(displayPnl) : '—'}
+                          </td>
+                          {/* Cum PnL */}
                           <td className={`px-3 py-1.5 text-right font-mono ${clsColor(a.cumPnl)}`}>
                             {n(a.cumPnl)}
                           </td>
+                          {/* Margin */}
                           <td className="px-3 py-1.5 text-right font-mono">
                             {a.marginBalanceBtc != null ? n(a.marginBalanceBtc, 4) : '—'}
                           </td>
-                          <td className="px-3 py-1.5 text-right font-mono">{n(a.equity, 4)}</td>
-                          <td className="px-3 py-1.5 text-right">
-                            {btcP ? usd(a.equity * btcP) : '—'}
+                          {/* Equity */}
+                          <td className="px-3 py-1.5 text-right font-mono">
+                            {n(a.equity, 4)}
                           </td>
                         </tr>
                       );

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -310,12 +310,6 @@ export default function RunDetailPage() {
     saveSettings(execForm);
   }, [execForm, saveSettings]);
 
-  // Polling — refetch every 5s while ACTIVE
-  useEffect(() => {
-    if (run.data?.status !== 'ACTIVE') return;
-    const interval = setInterval(() => { run.refetch(); }, 5_000);
-    return () => clearInterval(interval);
-  }, [run.data?.status, run.refetch]);
 
   const executeRun = async () => {
     if (!runId) return;
@@ -733,12 +727,13 @@ export default function RunDetailPage() {
     { label: 'Close',   value: 'close'                },
     { label: 'Mark',    value: 'settlement_unrealized' },
     { label: 'Expired', value: 'settlement_expired'   },
+    { label: 'Hold',    value: 'hold'                 },
   ];
 
   // filtered log (newest first) — year already scoped via yearActions
   // settlement_init is always represented by the pinned opening-balance row, so exclude it here
   const filteredLog = [...actionLog].filter(a => {
-    if (a.actionType === 'settlement_init' || a.actionType === 'hold') return false;
+    if (a.actionType === 'settlement_init') return false;
     if (logTypeFilter && a.actionType !== logTypeFilter) return false;
     if (logSearch) {
       const q = logSearch.toLowerCase();

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -136,14 +136,6 @@ function instrStrike(instrument?: string | null): number | null {
   return isNaN(k) ? null : k;
 }
 
-const ACTION_COLORS: Record<string, string> = {
-  settlement_init:       '#64748b',
-  settlement_unrealized: '#0ea5e9',
-  settlement_expired:    '#f59e0b',
-  open:                  '#22c55e',
-  close:                 '#ef4444',
-};
-
 const ACTION_BADGE: Record<string, { color: string; bg: string; label: string }> = {
   settlement_init:       { color: 'text-slate-500',  bg: 'bg-slate-100/60',  label: 'Init'     },
   settlement_unrealized: { color: 'text-sky-600',    bg: 'bg-sky-100/80',    label: 'Mark'     },
@@ -152,31 +144,49 @@ const ACTION_BADGE: Record<string, { color: string; bg: string; label: string }>
   close:                 { color: 'text-error',      bg: 'bg-error/10',      label: 'Close'    },
 };
 
-function cashflow(a: AgentAction): number | null {
-  const qty = a.quantity != null ? Number(a.quantity) : null;
-  const p   = a.price   != null ? Number(a.price)    : null;
-  if (qty == null || p == null) return null;
-  if (a.actionType === 'open')               return  p * qty;   // premium inflow
-  if (a.actionType === 'close')              return -(p * qty);  // buyback outflow
-  if (a.actionType === 'settlement_expired') return -(p * qty);  // settlement payout (0 if OTM)
+const OPTION_CATEGORIES = [
+  'Calls Opened',
+  'Calls Closed',
+  'Calls Expired',
+  'Puts Opened',
+  'Puts Closed',
+  'Puts Expired',
+] as const;
+
+const OPTION_COLORS: Record<string, string> = {
+  'Calls Opened':  '#22c55e',
+  'Calls Closed':  '#ef4444',
+  'Calls Expired': '#f59e0b',
+  'Puts Opened':   '#3b82f6',
+  'Puts Closed':   '#8b5cf6',
+  'Puts Expired':  '#f97316',
+};
+
+const OPTION_BADGE: Record<string, { color: string; bg: string }> = {
+  'Calls Opened':  { color: 'text-success',       bg: 'bg-success/10'       },
+  'Calls Closed':  { color: 'text-error',         bg: 'bg-error/10'         },
+  'Calls Expired': { color: 'text-amber-600',     bg: 'bg-amber-100/80'     },
+  'Puts Opened':   { color: 'text-blue-600',      bg: 'bg-blue-100/80'      },
+  'Puts Closed':   { color: 'text-violet-600',    bg: 'bg-violet-100/80'    },
+  'Puts Expired':  { color: 'text-orange-600',    bg: 'bg-orange-100/80'    },
+};
+
+function optionCategory(a: AgentAction): string | null {
+  if (!a.instrument) return null;
+  const parts = a.instrument.split('-');
+  const optType = parts[parts.length - 1];
+  if (optType !== 'C' && optType !== 'P') return null;
+  const kind = optType === 'C' ? 'Calls' : 'Puts';
+  if (a.actionType === 'open') return `${kind} Opened`;
+  if (a.actionType === 'close') return `${kind} Closed`;
+  if (a.actionType === 'settlement_expired') return `${kind} Expired`;
   return null;
 }
 
-// Within-day event order: settlement phase first, then trade actions
-const TYPE_ORDER: Record<string, number> = {
-  settlement_init:       0,
-  settlement_expired:    1,
-  settlement_unrealized: 2,
-  open:                  3,
-  close:                 4,
-};
-
+// Events are stored with sequential millisecond timestamps by run_session.py,
+// so a simple ascending sort is sufficient — no type-based secondary key needed.
 function sortActions(raw: AgentAction[]): AgentAction[] {
-  return [...raw].sort((a, b) => {
-    const dt = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-    if (dt !== 0) return dt;
-    return (TYPE_ORDER[a.actionType] ?? 5) - (TYPE_ORDER[b.actionType] ?? 5);
-  });
+  return [...raw].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 }
 
 const COMMON_LINE = { pointRadius: 0, borderWidth: 1.5, tension: 0.3 };
@@ -584,12 +594,13 @@ export default function RunDetailPage() {
       },
     });
 
-    // 7. Doughnut
-    const typeCnt: Record<string, number> = {};
+    // 7. Doughnut — option type breakdown
+    const optCnt: Record<string, number> = {};
     actions.forEach(a => {
-      typeCnt[a.actionType] = (typeCnt[a.actionType] || 0) + 1;
+      const cat = optionCategory(a);
+      if (cat) optCnt[cat] = (optCnt[cat] || 0) + 1;
     });
-    const pieL = Object.keys(typeCnt);
+    const pieL = OPTION_CATEGORIES.filter(k => (optCnt[k] ?? 0) > 0);
     const el7 = document.getElementById('c-pie') as HTMLCanvasElement | null;
     if (el7) {
       chartsRef.current['c-pie'] = new ChartJS<'doughnut'>(el7, {
@@ -598,8 +609,8 @@ export default function RunDetailPage() {
           labels: pieL,
           datasets: [
             {
-              data: pieL.map(k => typeCnt[k]),
-              backgroundColor: pieL.map(k => ACTION_COLORS[k] || '#94a3b8'),
+              data: pieL.map(k => optCnt[k]),
+              backgroundColor: pieL.map(k => OPTION_COLORS[k]),
               borderWidth: 1,
             },
           ],
@@ -654,45 +665,23 @@ export default function RunDetailPage() {
   const lastBtc = yearActions.length ? Number(yearActions[yearActions.length - 1].btcPrice) || 0 : 0;
   const finalEq = openingBalance + totalPnl;
 
-  // type breakdown
-  const typeSummary: Record<string, { count: number; total: number }> = {};
+  // option-type breakdown
+  const optionSummary: Record<string, { count: number; total: number }> = {};
   yearActions.forEach(a => {
-    if (!typeSummary[a.actionType]) typeSummary[a.actionType] = { count: 0, total: 0 };
-    typeSummary[a.actionType].count++;
-    typeSummary[a.actionType].total += Number(a.pnlBtc) || 0;
+    const cat = optionCategory(a);
+    if (!cat) return;
+    if (!optionSummary[cat]) optionSummary[cat] = { count: 0, total: 0 };
+    optionSummary[cat].count++;
+    optionSummary[cat].total += Number(a.pnlBtc) || 0;
   });
 
-  // cumulative realized pnl + per-row equity
-  // equity = margin − Σ(mktPrem × size) for open positions
-  // mirrors the env: equity_btc = margin_balance + unrealized_btc, where unrealized_btc = −liability
+  // equity and cashflowBtc are computed by run_session.py and stored in the DB.
+  // The app only needs to derive cumPnl = equity − openingBalance.
   const actionLog = (() => {
-    let realizedPnl = 0; // used only as fallback when marginBalanceBtc is missing
-    const openPos = new Map<string, { size: number; mktPrem: number }>();
-
     return yearActions.map(a => {
-      realizedPnl += Number(a.pnlBtc) || 0;
-
-      const instr = a.instrument ?? '';
-      const qty   = a.quantity != null ? Number(a.quantity) : 0;
-      const price = a.price    != null ? Number(a.price)    : 0;
-
-      if (a.actionType === 'open') {
-        openPos.set(instr, { size: qty, mktPrem: price });
-      } else if (a.actionType === 'settlement_unrealized') {
-        const existing = openPos.get(instr);
-        openPos.set(instr, { size: existing?.size ?? qty, mktPrem: price });
-      } else if (a.actionType === 'close' || a.actionType === 'settlement_expired') {
-        openPos.delete(instr);
-      }
-
-      let totalLiability = 0;
-      for (const pos of openPos.values()) totalLiability += pos.mktPrem * pos.size;
-
-      const margin = a.marginBalanceBtc != null ? Number(a.marginBalanceBtc) : openingBalance + realizedPnl;
-      const equity = margin - totalLiability;
-      const cumPnl = equity - openingBalance; // total P&L = equity change from opening balance
-
-      return { ...a, cumPnl, equity };
+      const equity = a.equityBtc != null ? Number(a.equityBtc) : (a.marginBalanceBtc != null ? Number(a.marginBalanceBtc) : 0);
+      const cumPnl = equity - openingBalance;
+      return { ...a, equity, cumPnl };
     });
   })();
 
@@ -1110,46 +1099,45 @@ export default function RunDetailPage() {
               <ChartBox id="c-iv" title="IV Rank & Portfolio Delta" height={200} />
             </div>
 
-            {/* Action breakdown */}
+            {/* Option breakdown */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-              <ChartBox id="c-pie" title="Action Breakdown" height={200} />
+              <ChartBox id="c-pie" title="Option Breakdown" height={200} />
               <Card>
                 <p className="text-text-secondary text-xs font-semibold uppercase tracking-wider mb-3">
-                  By Action Type
+                  By Option Type
                 </p>
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-surface">
-                      <th className="text-left text-text-muted font-medium py-2">Type</th>
+                      <th className="text-left text-text-muted font-medium py-2">Category</th>
                       <th className="text-right text-text-muted font-medium py-2">Count</th>
                       <th className="text-right text-text-muted font-medium py-2">Total (₿)</th>
                       <th className="text-right text-text-muted font-medium py-2">Avg (₿)</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {Object.entries(typeSummary)
-                      .sort((a, b) => b[1].count - a[1].count)
-                      .map(([type, s]) => {
-                        const avg = s.total / s.count;
-                        const style = ACTION_BADGE[type] ?? { color: 'text-text-secondary', bg: 'bg-surface', label: type };
-                        return (
-                          <tr key={type} className="border-b border-surface/50">
-                            <td className="py-2">
-                              <Badge
-                                text={style.label}
-                                variant="custom"
-                                customColor={style.color}
-                                customBgColor={style.bg}
-                              />
-                            </td>
-                            <td className="text-right text-text-primary font-mono">{s.count}</td>
-                            <td className={`text-right font-mono ${clsColor(s.total)}`}>
-                              {n(s.total)}
-                            </td>
-                            <td className={`text-right font-mono ${clsColor(avg)}`}>{n(avg)}</td>
-                          </tr>
-                        );
-                      })}
+                    {OPTION_CATEGORIES.map(cat => {
+                      const s = optionSummary[cat] ?? { count: 0, total: 0 };
+                      const avg = s.count ? s.total / s.count : 0;
+                      const style = OPTION_BADGE[cat];
+                      return (
+                        <tr key={cat} className="border-b border-surface/50">
+                          <td className="py-2">
+                            <Badge
+                              text={cat}
+                              variant="custom"
+                              customColor={style.color}
+                              customBgColor={style.bg}
+                            />
+                          </td>
+                          <td className="text-right text-text-primary font-mono">{s.count}</td>
+                          <td className={`text-right font-mono ${clsColor(s.total)}`}>
+                            {n(s.total)}
+                          </td>
+                          <td className={`text-right font-mono ${clsColor(avg)}`}>{n(avg)}</td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </Card>
@@ -1235,15 +1223,13 @@ export default function RunDetailPage() {
                           ? (btcP != null && k != null && k > btcP)
                           : false;
 
-                      // For open: price = original premium (executedPrice not set yet).
-                      // For mark/expired/close: executedPrice = original premium, price = current mark/intrinsic/buyback.
-                      // At open, mktPrem = origPrem (just sold at market → size×(orig−mkt) = 0).
-                      const isOpen   = a.actionType === 'open';
-                      const origPrem = isOpen ? a.price : a.executedPrice;
-                      const mktPrem  = isOpen ? a.price : a.price;   // open: same as orig; others: current mark
+                      // executedPrice is always the original premium (set by run_session for all types).
+                      // price is the current mark/intrinsic/buyback depending on event type.
+                      // At open, both are equal (just sold at market → unrealized = 0).
+                      const origPrem = a.executedPrice;
+                      const mktPrem  = a.price;
 
-                      // PnL: for unrealized marks, derive from size × (orig − mkt) since pnlBtc is null.
-                      // For open: size×(orig−mkt) = 0, which is intentional.
+                      // For unrealized marks pnlBtc is null — derive display PnL from size × (orig − mkt).
                       const unrealPnl =
                         a.pnlBtc == null && origPrem != null && mktPrem != null && a.quantity != null
                           ? Number(a.quantity) * (Number(origPrem) - Number(mktPrem))
@@ -1292,15 +1278,10 @@ export default function RunDetailPage() {
                           <td className="px-3 py-1.5 text-right font-mono text-text-muted">
                             {mktPrem != null ? n(mktPrem, 6) : '—'}
                           </td>
-                          {/* Cashflow: actual BTC in (+) or out (−) */}
-                          {(() => {
-                            const cf = cashflow(a);
-                            return (
-                              <td className={`px-3 py-1.5 text-right font-mono ${cf != null ? clsColor(cf) : 'text-text-muted'}`}>
-                                {cf != null ? n(cf) : '—'}
-                              </td>
-                            );
-                          })()}
+                          {/* Cashflow: actual BTC in (+) or out (−), stored by run_session */}
+                          <td className={`px-3 py-1.5 text-right font-mono ${a.cashflowBtc != null ? clsColor(Number(a.cashflowBtc)) : 'text-text-muted'}`}>
+                            {a.cashflowBtc != null ? n(a.cashflowBtc) : '—'}
+                          </td>
                           {/* Fee — shown as negative (it's a cost) */}
                           <td className="px-3 py-1.5 text-right font-mono text-error">
                             {a.feeBtc != null && Number(a.feeBtc) !== 0

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -18,13 +18,57 @@ import {
   type ChartConfiguration,
 } from 'chart.js';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faArrowLeft, faRobot } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowLeft,
+  faRobot,
+  faChevronDown,
+  faChevronUp,
+  faPlay,
+  faPause,
+  faStop,
+} from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import { AgentError } from '@/components/features/DeribitAgent/AgentError';
-import { useDeribitFetch, type AgentRun, type AgentAction } from '@/lib/deribit-agent/client';
+import TextInput from '@/components/ui/Input/TextInput';
+import SliderInput from '@/components/ui/Input/SliderInput';
+import { useDeribitFetch, agentFetch, type AgentRun, type AgentAction } from '@/lib/deribit-agent/client';
 import { RUN_STATUS_BADGE } from '@/lib/deribit-agent/ui';
+
+const EXEC_STRATEGY_OPTIONS = [
+  { value: 'short_call', label: 'Short Call', desc: 'Sell calls Δ20–Δ80' },
+  { value: 'short_put', label: 'Short Put', desc: 'Sell puts Δ10–Δ50' },
+  { value: 'delta_neutral', label: 'Delta Neutral', desc: 'Balanced call + put' },
+];
+
+function aggressionLabel(v: number) {
+  if (v <= 0.2) return 'Very Passive';
+  if (v <= 0.4) return 'Passive';
+  if (v <= 0.6) return 'Balanced';
+  if (v <= 0.8) return 'Aggressive';
+  return 'Very Aggressive';
+}
+
+function mkBlankExec() {
+  const today = new Date();
+  return {
+    dataFrom:          '2022-03-01',
+    dataTo:            today.toISOString().slice(0, 10),
+    allowedStrategies: ['short_call', 'short_put', 'delta_neutral'] as string[],
+    maxDrawdownLimit:  0.20,
+    aggressionLevel:   0.5,
+    positionSizePct:   1.0,
+    maxPositionBtc:    5.0,
+    minOrderSize:      0.1,
+    expiryDays:        7,
+    maxMarginRatio:    0.8,
+    deltaThreshold:    0.30,
+    deltaPenaltyCoef:  0.002,
+    riskFreeRate:      0.05,
+    fastMargin:        false,
+  };
+}
 
 ChartJS.register(
   LineController,
@@ -177,6 +221,80 @@ export default function RunDetailPage() {
   const [chartsReady, setChartsReady] = useState(false);
   const [logTypeFilter, setLogTypeFilter] = useState('');
   const [logSearch, setLogSearch] = useState('');
+
+  // Execution accordion
+  const [showExec, setShowExec] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [execForm, setExecForm] = useState(mkBlankExec);
+  const [executing, setExecuting] = useState(false);
+  const [actioning, setActioning] = useState(false);
+
+  const toggleExecStrategy = (s: string) => {
+    setExecForm(f => ({
+      ...f,
+      allowedStrategies: f.allowedStrategies.includes(s)
+        ? f.allowedStrategies.filter(x => x !== s)
+        : [...f.allowedStrategies, s],
+    }));
+  };
+
+  const executeRun = async () => {
+    if (!runId) return;
+    if (!execForm.allowedStrategies.length) {
+      const { toast } = await import('react-hot-toast');
+      toast.error('Enable at least one strategy.');
+      return;
+    }
+    setExecuting(true);
+    try {
+      await agentFetch(`/agent/runs/${runId}/execute`, {
+        method: 'POST',
+        body: JSON.stringify({
+          dataFrom: execForm.dataFrom || undefined,
+          dataTo: execForm.dataTo || undefined,
+          envOverrides: {
+            allowed_actions:       execForm.allowedStrategies,
+            randomize_conditioning: false,
+            max_drawdown_limit:    execForm.maxDrawdownLimit,
+            aggression_level:      execForm.aggressionLevel,
+            position_size_pct:     execForm.positionSizePct,
+            max_position_btc:      execForm.maxPositionBtc,
+            min_order_size:        execForm.minOrderSize,
+            expiry_days:           execForm.expiryDays,
+            max_margin_ratio:      execForm.maxMarginRatio,
+            delta_threshold:       execForm.deltaThreshold,
+            delta_penalty_coef:    execForm.deltaPenaltyCoef,
+            risk_free_rate:        execForm.riskFreeRate,
+            fast_margin:           execForm.fastMargin,
+          },
+        }),
+      });
+      const { toast } = await import('react-hot-toast');
+      toast.success('Execution queued.');
+      run.refetch();
+    } catch (e) {
+      const { toast } = await import('react-hot-toast');
+      toast.error(e instanceof Error ? e.message : 'Execute failed.');
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const runControl = async (action: 'pause' | 'resume' | 'stop') => {
+    if (!runId) return;
+    setActioning(true);
+    try {
+      await agentFetch(`/agent/runs/${runId}/${action}`, { method: 'POST' });
+      const { toast } = await import('react-hot-toast');
+      toast.success(`Agent ${action === 'stop' ? 'stopped' : action === 'pause' ? 'paused' : 'resumed'}.`);
+      run.refetch();
+    } catch (e) {
+      const { toast } = await import('react-hot-toast');
+      toast.error(e instanceof Error ? e.message : `Failed to ${action}.`);
+    } finally {
+      setActioning(false);
+    }
+  };
 
   const destroyCharts = () => {
     Object.values(chartsRef.current).forEach(c => c.destroy());
@@ -642,6 +760,268 @@ export default function RunDetailPage() {
                 )}
               </div>
             )}
+
+            {/* Execution Settings accordion */}
+            <Card className="mt-4">
+              <button
+                type="button"
+                className="w-full flex items-center justify-between"
+                onClick={() => setShowExec(v => !v)}
+              >
+                <span className="text-sm font-semibold text-text-primary">Execution Settings</span>
+                <FontAwesomeIcon
+                  icon={showExec ? faChevronUp : faChevronDown}
+                  className="w-3.5 h-3.5 text-text-muted"
+                />
+              </button>
+
+              {showExec && (
+                <div className="mt-5 space-y-6">
+
+                  {/* ── Date range ───────────────────────────────────────────── */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <TextInput
+                      label="Data From"
+                      type="date"
+                      value={execForm.dataFrom}
+                      onChange={v => setExecForm(f => ({ ...f, dataFrom: v }))}
+                    />
+                    <TextInput
+                      label="Data To"
+                      type="date"
+                      value={execForm.dataTo}
+                      onChange={v => setExecForm(f => ({ ...f, dataTo: v }))}
+                    />
+                  </div>
+
+                  {/* ── Strategies ───────────────────────────────────────────── */}
+                  <div>
+                    <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+                      Strategies
+                    </p>
+                    <div className="grid grid-cols-3 gap-2">
+                      {EXEC_STRATEGY_OPTIONS.map(s => {
+                        const active = execForm.allowedStrategies.includes(s.value);
+                        return (
+                          <button
+                            key={s.value}
+                            type="button"
+                            onClick={() => toggleExecStrategy(s.value)}
+                            className={`text-left px-3 py-2.5 rounded-lg border-2 transition-colors ${
+                              active
+                                ? 'border-brand bg-brand/5 text-brand'
+                                : 'border-input-border text-text-secondary hover:border-brand/50'
+                            }`}
+                          >
+                            <div className="text-sm font-medium">{s.label}</div>
+                            <div className="text-xs text-text-muted mt-0.5">{s.desc}</div>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* ── Risk & aggression ────────────────────────────────────── */}
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <SliderInput
+                      label="Max Drawdown Limit"
+                      value={execForm.maxDrawdownLimit * 100}
+                      onChange={v => setExecForm(f => ({ ...f, maxDrawdownLimit: v / 100 }))}
+                      min={5} max={50} step={5}
+                      formatValue={v => `${v.toFixed(0)}%`}
+                      minLabel="5% (tight)" maxLabel="50% (loose)"
+                      hint="Stop trading when peak-to-trough equity loss exceeds this."
+                    />
+                    <SliderInput
+                      label="Aggression Level"
+                      value={execForm.aggressionLevel * 100}
+                      onChange={v => setExecForm(f => ({ ...f, aggressionLevel: v / 100 }))}
+                      min={0} max={100} step={10}
+                      formatValue={v => aggressionLabel(v / 100)}
+                      minLabel="Passive" maxLabel="Aggressive"
+                      hint="Scales position size 30%–100% of configured max."
+                    />
+                  </div>
+
+                  {/* ── Position sizing ──────────────────────────────────────── */}
+                  <div>
+                    <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                      Position Sizing
+                    </p>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                      <SliderInput
+                        label="Position Size %"
+                        value={execForm.positionSizePct * 100}
+                        onChange={v => setExecForm(f => ({ ...f, positionSizePct: v / 100 }))}
+                        min={5} max={100} step={5}
+                        formatValue={v => `${v.toFixed(0)}%`}
+                        minLabel="5%" maxLabel="100%"
+                        hint="Fraction of margin allocated per leg."
+                      />
+                      <TextInput
+                        label="Max Position BTC"
+                        placeholder="5.0"
+                        value={String(execForm.maxPositionBtc)}
+                        onChange={v => setExecForm(f => ({ ...f, maxPositionBtc: parseFloat(v) || f.maxPositionBtc }))}
+                      />
+                      <TextInput
+                        label="Min Order Size BTC"
+                        placeholder="0.1"
+                        value={String(execForm.minOrderSize)}
+                        onChange={v => setExecForm(f => ({ ...f, minOrderSize: parseFloat(v) || f.minOrderSize }))}
+                      />
+                    </div>
+                  </div>
+
+                  {/* ── Options structure ────────────────────────────────────── */}
+                  <div>
+                    <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                      Options Structure
+                    </p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div>
+                        <p className="text-xs text-text-muted mb-2">Expiry (DTE)</p>
+                        <div className="flex gap-2">
+                          {[7, 14, 21, 30].map(d => (
+                            <button
+                              key={d}
+                              type="button"
+                              onClick={() => setExecForm(f => ({ ...f, expiryDays: d }))}
+                              className={`flex-1 py-2 rounded-lg border-2 text-sm font-medium transition-colors ${
+                                execForm.expiryDays === d
+                                  ? 'border-brand bg-brand/5 text-brand'
+                                  : 'border-input-border text-text-secondary hover:border-brand/50'
+                              }`}
+                            >
+                              {d}d
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <SliderInput
+                        label="Max Margin Ratio"
+                        value={execForm.maxMarginRatio * 100}
+                        onChange={v => setExecForm(f => ({ ...f, maxMarginRatio: v / 100 }))}
+                        min={50} max={95} step={5}
+                        formatValue={v => `${v.toFixed(0)}%`}
+                        minLabel="50%" maxLabel="95%"
+                        hint="Max portfolio margin utilization before blocking new trades."
+                      />
+                    </div>
+                  </div>
+
+                  {/* ── Delta management ─────────────────────────────────────── */}
+                  <div>
+                    <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                      Delta Management
+                    </p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <SliderInput
+                        label="Delta Threshold"
+                        value={execForm.deltaThreshold * 100}
+                        onChange={v => setExecForm(f => ({ ...f, deltaThreshold: v / 100 }))}
+                        min={10} max={80} step={5}
+                        formatValue={v => `${v.toFixed(0)}%`}
+                        minLabel="10% (strict)" maxLabel="80% (loose)"
+                        hint="Net delta overshoot allowed before penalty kicks in."
+                      />
+                      <TextInput
+                        label="Delta Penalty Coef"
+                        placeholder="0.002"
+                        value={String(execForm.deltaPenaltyCoef)}
+                        onChange={v => setExecForm(f => ({ ...f, deltaPenaltyCoef: parseFloat(v) || f.deltaPenaltyCoef }))}
+                      />
+                    </div>
+                  </div>
+
+                  {/* ── Advanced (collapsible) ───────────────────────────────── */}
+                  <div>
+                    <button
+                      type="button"
+                      className="flex items-center gap-2 text-xs font-semibold text-text-muted uppercase tracking-wider hover:text-text-primary transition-colors"
+                      onClick={() => setShowAdvanced(v => !v)}
+                    >
+                      <FontAwesomeIcon icon={showAdvanced ? faChevronUp : faChevronDown} className="w-3 h-3" />
+                      Advanced
+                    </button>
+                    {showAdvanced && (
+                      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4 pl-1">
+                        <TextInput
+                          label="Risk Free Rate"
+                          placeholder="0.05"
+                          value={String(execForm.riskFreeRate)}
+                          onChange={v => setExecForm(f => ({ ...f, riskFreeRate: parseFloat(v) || f.riskFreeRate }))}
+                        />
+                        <div>
+                          <p className="text-xs text-text-muted mb-2">Fast Margin</p>
+                          <button
+                            type="button"
+                            onClick={() => setExecForm(f => ({ ...f, fastMargin: !f.fastMargin }))}
+                            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+                              execForm.fastMargin ? 'bg-brand' : 'bg-input-border'
+                            }`}
+                          >
+                            <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                              execForm.fastMargin ? 'translate-x-6' : 'translate-x-1'
+                            }`} />
+                          </button>
+                          <p className="text-xs text-text-muted mt-1">
+                            Skip IV shocks in margin calc — faster, less precise.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* ── Action buttons ───────────────────────────────────────── */}
+                  <div className="flex gap-3 flex-wrap pt-1 border-t border-surface">
+                    <button
+                      type="button"
+                      disabled={executing}
+                      onClick={executeRun}
+                      className="inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
+                    >
+                      <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
+                      {executing ? 'Queuing…' : 'Execute'}
+                    </button>
+                    {runData.status === 'ACTIVE' && (
+                      <button
+                        type="button"
+                        disabled={actioning}
+                        onClick={() => runControl('pause')}
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-yellow-400/50 text-yellow-400 hover:bg-yellow-400/10 disabled:opacity-50 transition-colors"
+                      >
+                        <FontAwesomeIcon icon={faPause} className="w-3 h-3" />
+                        Pause
+                      </button>
+                    )}
+                    {runData.status === 'PAUSED' && (
+                      <button
+                        type="button"
+                        disabled={actioning}
+                        onClick={() => runControl('resume')}
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-success/50 text-success hover:bg-success/10 disabled:opacity-50 transition-colors"
+                      >
+                        <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
+                        Resume
+                      </button>
+                    )}
+                    {(runData.status === 'ACTIVE' || runData.status === 'PAUSED') && (
+                      <button
+                        type="button"
+                        disabled={actioning}
+                        onClick={() => runControl('stop')}
+                        className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-error/50 text-error hover:bg-error/10 disabled:opacity-50 transition-colors"
+                      >
+                        <FontAwesomeIcon icon={faStop} className="w-3 h-3" />
+                        Stop
+                      </button>
+                    )}
+                  </div>
+
+                </div>
+              )}
+            </Card>
 
             {/* Stat cards */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-5">

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Chart as ChartJS,
   LineController,
@@ -26,6 +26,7 @@ import {
   faPlay,
   faPause,
   faStop,
+  faRotateRight,
 } from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
@@ -33,14 +34,15 @@ import { Badge } from '@/components/ui/Badge';
 import { AgentError } from '@/components/features/DeribitAgent/AgentError';
 import TextInput from '@/components/ui/Input/TextInput';
 import SliderInput from '@/components/ui/Input/SliderInput';
-import { useDeribitFetch, agentFetch, type AgentRun, type AgentAction } from '@/lib/deribit-agent/client';
+import { useDeribitFetch, agentFetch, type AgentRun, type AgentAction, type ExecutionSettings } from '@/lib/deribit-agent/client';
 import { RUN_STATUS_BADGE } from '@/lib/deribit-agent/ui';
 
-const EXEC_STRATEGY_OPTIONS = [
-  { value: 'short_call', label: 'Short Call', desc: 'Sell calls Δ20–Δ80' },
-  { value: 'short_put', label: 'Short Put', desc: 'Sell puts Δ10–Δ50' },
-  { value: 'delta_neutral', label: 'Delta Neutral', desc: 'Balanced call + put' },
+const EXEC_STRATEGY_CHIPS = [
+  { value: 'short_call',    label: 'Short Call',    desc: 'Calls Δ20–Δ80', ids: [1,2,3,4,5,6,7] },
+  { value: 'short_put',     label: 'Short Put',     desc: 'Puts Δ10–Δ50',  ids: [8,9,10,11,12] },
+  { value: 'delta_neutral', label: 'Delta Neutral', desc: 'Balanced call + put', ids: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] },
 ];
+const ALL_EXEC_ACTION_IDS = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26];
 
 function aggressionLabel(v: number) {
   if (v <= 0.2) return 'Very Passive';
@@ -53,20 +55,43 @@ function aggressionLabel(v: number) {
 function mkBlankExec() {
   const today = new Date();
   return {
-    dataFrom:          '2022-03-01',
-    dataTo:            today.toISOString().slice(0, 10),
-    allowedStrategies: ['short_call', 'short_put', 'delta_neutral'] as string[],
-    maxDrawdownLimit:  0.20,
-    aggressionLevel:   0.5,
-    positionSizePct:   1.0,
-    maxPositionBtc:    5.0,
-    minOrderSize:      0.1,
-    expiryDays:        7,
-    maxMarginRatio:    0.8,
-    deltaThreshold:    0.30,
-    deltaPenaltyCoef:  0.002,
-    riskFreeRate:      0.05,
-    fastMargin:        false,
+    dataFrom:         '2022-03-01',
+    dataTo:           today.toISOString().slice(0, 10),
+    allowed_actions:  [...ALL_EXEC_ACTION_IDS] as number[],
+    max_drawdown_limit: 0.20,
+    aggression_level:   0.5,
+    position_size_pct:  1.0,
+    max_position_btc:   5.0,
+    min_order_size:     0.1,
+    expiry_days_min:    7,
+    expiry_days_max:    7,
+    roll_dte_threshold: 0,
+    max_margin_ratio:   0.8,
+    delta_threshold:    0.30,
+    delta_penalty_coef: 0.002,
+    risk_free_rate:     0.05,
+    fast_margin:        false,
+  };
+}
+
+function execFormFromSettings(s: ExecutionSettings, fallback: ReturnType<typeof mkBlankExec>): ReturnType<typeof mkBlankExec> {
+  return {
+    dataFrom:           (s.dataFrom           ?? fallback.dataFrom),
+    dataTo:             (s.dataTo             ?? fallback.dataTo),
+    allowed_actions:    (s.allowed_actions     ?? fallback.allowed_actions),
+    max_drawdown_limit: (s.max_drawdown_limit  ?? fallback.max_drawdown_limit),
+    aggression_level:   (s.aggression_level    ?? fallback.aggression_level),
+    position_size_pct:  (s.position_size_pct   ?? fallback.position_size_pct),
+    max_position_btc:   (s.max_position_btc    ?? fallback.max_position_btc),
+    min_order_size:     (s.min_order_size       ?? fallback.min_order_size),
+    expiry_days_min:    (s.expiry_days_min      ?? fallback.expiry_days_min),
+    expiry_days_max:    (s.expiry_days_max      ?? fallback.expiry_days_max),
+    roll_dte_threshold: (s.roll_dte_threshold   ?? fallback.roll_dte_threshold),
+    max_margin_ratio:   (s.max_margin_ratio     ?? fallback.max_margin_ratio),
+    delta_threshold:    (s.delta_threshold      ?? fallback.delta_threshold),
+    delta_penalty_coef: (s.delta_penalty_coef   ?? fallback.delta_penalty_coef),
+    risk_free_rate:     (s.risk_free_rate        ?? fallback.risk_free_rate),
+    fast_margin:        (s.fast_margin           ?? fallback.fast_margin),
   };
 }
 
@@ -155,20 +180,20 @@ const OPTION_CATEGORIES = [
 
 const OPTION_COLORS: Record<string, string> = {
   'Calls Opened':  '#22c55e',
-  'Calls Closed':  '#ef4444',
-  'Calls Expired': '#f59e0b',
-  'Puts Opened':   '#3b82f6',
-  'Puts Closed':   '#8b5cf6',
-  'Puts Expired':  '#f97316',
+  'Calls Closed':  '#15803d',
+  'Calls Expired': '#86efac',
+  'Puts Opened':   '#ef4444',
+  'Puts Closed':   '#b91c1c',
+  'Puts Expired':  '#fca5a5',
 };
 
 const OPTION_BADGE: Record<string, { color: string; bg: string }> = {
-  'Calls Opened':  { color: 'text-success',       bg: 'bg-success/10'       },
-  'Calls Closed':  { color: 'text-error',         bg: 'bg-error/10'         },
-  'Calls Expired': { color: 'text-amber-600',     bg: 'bg-amber-100/80'     },
-  'Puts Opened':   { color: 'text-blue-600',      bg: 'bg-blue-100/80'      },
-  'Puts Closed':   { color: 'text-violet-600',    bg: 'bg-violet-100/80'    },
-  'Puts Expired':  { color: 'text-orange-600',    bg: 'bg-orange-100/80'    },
+  'Calls Opened':  { color: 'text-green-600',     bg: 'bg-green-100/80'     },
+  'Calls Closed':  { color: 'text-green-800',     bg: 'bg-green-200/80'     },
+  'Calls Expired': { color: 'text-green-500',     bg: 'bg-green-50'         },
+  'Puts Opened':   { color: 'text-red-600',       bg: 'bg-red-100/80'       },
+  'Puts Closed':   { color: 'text-red-800',       bg: 'bg-red-200/80'       },
+  'Puts Expired':  { color: 'text-red-400',       bg: 'bg-red-50'           },
 };
 
 function optionCategory(a: AgentAction): string | null {
@@ -210,7 +235,7 @@ function ChartBox({ title, id, height = 200 }: { title: string; id: string; heig
 
 interface RunDetail extends AgentRun {
   startedAt?: string;
-  session?: { name: string; algorithm: string } | null;
+  session?: { name: string; algorithm: string; hyperparams?: { env?: ExecutionSettings } } | null;
   actions?: AgentAction[];
 }
 
@@ -233,31 +258,66 @@ export default function RunDetailPage() {
   // Execution accordion
   const [showExec, setShowExec] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [execForm, setExecForm] = useState<ReturnType<typeof mkBlankExec>>(() => {
-    if (typeof window === 'undefined') return mkBlankExec();
-    try {
-      const saved = localStorage.getItem('deribit:exec-settings');
-      if (saved) return { ...mkBlankExec(), ...JSON.parse(saved) };
-    } catch {}
-    return mkBlankExec();
-  });
+  const [execForm, setExecForm] = useState<ReturnType<typeof mkBlankExec>>(mkBlankExec);
   const [executing, setExecuting] = useState(false);
   const [actioning, setActioning] = useState(false);
+  const [settingsSaved, setSettingsSaved] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const execFormLoaded = useRef(false);
 
-  const toggleExecStrategy = (s: string) => {
-    setExecForm(f => ({
-      ...f,
-      allowedStrategies: f.allowedStrategies.includes(s)
-        ? f.allowedStrategies.filter(x => x !== s)
-        : [...f.allowedStrategies, s],
-    }));
+  // Strategy chip helpers
+  const isChipActive = (ids: number[]) => ids.every(id => execForm.allowed_actions.includes(id));
+  const toggleChip = (ids: number[]) => {
+    if (isChipActive(ids)) {
+      setExecForm(f => ({ ...f, allowed_actions: f.allowed_actions.filter(id => !ids.includes(id)) }));
+    } else {
+      setExecForm(f => ({ ...f, allowed_actions: [...new Set([...f.allowed_actions, ...ids])] }));
+    }
   };
+
+  // Populate execForm from DB settings once run data is available
+  useEffect(() => {
+    if (!run.data || execFormLoaded.current) return;
+    execFormLoaded.current = true;
+    const stored = run.data.executionSettings;
+    const sessionEnv = (run.data as any).session?.hyperparams?.env as ExecutionSettings | undefined;
+    const source = stored && Object.keys(stored).length > 0 ? stored : sessionEnv;
+    if (source) setExecForm(execFormFromSettings(source, mkBlankExec()));
+  }, [run.data]);
+
+  // Debounce-save execForm to DB
+  const saveSettings = useCallback((form: ReturnType<typeof mkBlankExec>) => {
+    if (!runId || !execFormLoaded.current) return;
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        await agentFetch(`/agent/runs/${runId}/settings`, {
+          method: 'PATCH',
+          body: JSON.stringify(form),
+        });
+        setSettingsSaved(true);
+        setTimeout(() => setSettingsSaved(false), 1500);
+      } catch {}
+    }, 800);
+  }, [runId]);
+
+  useEffect(() => {
+    if (!execFormLoaded.current) return;
+    saveSettings(execForm);
+  }, [execForm, saveSettings]);
+
+  // Polling — refetch every 5s while ACTIVE
+  useEffect(() => {
+    if (run.data?.status !== 'ACTIVE') return;
+    const interval = setInterval(() => { run.refetch(); }, 5_000);
+    return () => clearInterval(interval);
+  }, [run.data?.status, run.refetch]);
 
   const executeRun = async () => {
     if (!runId) return;
-    if (!execForm.allowedStrategies.length) {
+    if (!execForm.allowed_actions.length) {
       const { toast } = await import('react-hot-toast');
-      toast.error('Enable at least one strategy.');
+      toast.error('Enable at least one action.');
       return;
     }
     setExecuting(true);
@@ -266,27 +326,11 @@ export default function RunDetailPage() {
         method: 'POST',
         body: JSON.stringify({
           dataFrom: execForm.dataFrom || undefined,
-          dataTo: execForm.dataTo || undefined,
-          envOverrides: {
-            allowed_actions:       execForm.allowedStrategies,
-            randomize_conditioning: false,
-            max_drawdown_limit:    execForm.maxDrawdownLimit,
-            aggression_level:      execForm.aggressionLevel,
-            position_size_pct:     execForm.positionSizePct,
-            max_position_btc:      execForm.maxPositionBtc,
-            min_order_size:        execForm.minOrderSize,
-            expiry_days:           execForm.expiryDays,
-            max_margin_ratio:      execForm.maxMarginRatio,
-            delta_threshold:       execForm.deltaThreshold,
-            delta_penalty_coef:    execForm.deltaPenaltyCoef,
-            risk_free_rate:        execForm.riskFreeRate,
-            fast_margin:           execForm.fastMargin,
-          },
+          dataTo:   execForm.dataTo   || undefined,
         }),
       });
       const { toast } = await import('react-hot-toast');
       toast.success('Execution queued.');
-      run.refetch();
     } catch (e) {
       const { toast } = await import('react-hot-toast');
       toast.error(e instanceof Error ? e.message : 'Execute failed.');
@@ -315,10 +359,6 @@ export default function RunDetailPage() {
     Object.values(chartsRef.current).forEach(c => c.destroy());
     chartsRef.current = {};
   };
-
-  useEffect(() => {
-    try { localStorage.setItem('deribit:exec-settings', JSON.stringify(execForm)); } catch {}
-  }, [execForm]);
 
   useEffect(() => {
     if (!run.data || !actionsReq.data) return;
@@ -594,40 +634,6 @@ export default function RunDetailPage() {
       },
     });
 
-    // 7. Doughnut — option type breakdown
-    const optCnt: Record<string, number> = {};
-    actions.forEach(a => {
-      const cat = optionCategory(a);
-      if (cat) optCnt[cat] = (optCnt[cat] || 0) + 1;
-    });
-    const pieL = OPTION_CATEGORIES.filter(k => (optCnt[k] ?? 0) > 0).sort((a, b) => optCnt[b] - optCnt[a]);
-    const el7 = document.getElementById('c-pie') as HTMLCanvasElement | null;
-    if (el7) {
-      chartsRef.current['c-pie'] = new ChartJS<'doughnut'>(el7, {
-        type: 'doughnut',
-        data: {
-          labels: pieL,
-          datasets: [
-            {
-              data: pieL.map(k => optCnt[k]),
-              backgroundColor: pieL.map(k => OPTION_COLORS[k]),
-              borderWidth: 1,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          cutout: '60%',
-          plugins: {
-            legend: {
-              position: 'right',
-              labels: { font: { size: 11 }, color: '#9ca3af', padding: 10 },
-            },
-          },
-        },
-      });
-    }
   }
 
   // ── Derived stats ────────────────────────────────────────────────────────────
@@ -685,11 +691,17 @@ export default function RunDetailPage() {
     });
   })();
 
-  // unique action types within selected year
-  const uniqueTypes = Array.from(new Set(yearActions.map(a => a.actionType)));
+  const LOG_TYPE_TABS = [
+    { label: 'Open',    value: 'open'                 },
+    { label: 'Close',   value: 'close'                },
+    { label: 'Mark',    value: 'settlement_unrealized' },
+    { label: 'Expired', value: 'settlement_expired'   },
+  ];
 
   // filtered log (newest first) — year already scoped via yearActions
+  // settlement_init is always represented by the pinned opening-balance row, so exclude it here
   const filteredLog = [...actionLog].filter(a => {
+    if (a.actionType === 'settlement_init') return false;
     if (logTypeFilter && a.actionType !== logTypeFilter) return false;
     if (logSearch) {
       const q = logSearch.toLowerCase();
@@ -770,6 +782,14 @@ export default function RunDetailPage() {
                     Started {new Date(runData.startedAt).toLocaleString()}
                   </span>
                 )}
+                <button
+                  type="button"
+                  title="Reload stats"
+                  onClick={() => { run.refetch(); actionsReq.refetch(); }}
+                  className="ml-auto p-1.5 rounded text-text-muted hover:text-text-primary hover:bg-surface transition-colors"
+                >
+                  <FontAwesomeIcon icon={faRotateRight} className="w-3.5 h-3.5" />
+                </button>
               </div>
             )}
 
@@ -780,7 +800,10 @@ export default function RunDetailPage() {
                 className="w-full flex items-center justify-between"
                 onClick={() => setShowExec(v => !v)}
               >
-                <span className="text-sm font-semibold text-text-primary">Execution Settings</span>
+                <span className="text-sm font-semibold text-text-primary">
+                  Execution Settings
+                  {settingsSaved && <span className="ml-2 text-xs text-success font-normal">Saved</span>}
+                </span>
                 <FontAwesomeIcon
                   icon={showExec ? faChevronUp : faChevronDown}
                   className="w-3.5 h-3.5 text-text-muted"
@@ -809,24 +832,24 @@ export default function RunDetailPage() {
                   {/* ── Strategies ───────────────────────────────────────────── */}
                   <div>
                     <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
-                      Strategies
+                      Open Strategies
                     </p>
-                    <div className="grid grid-cols-3 gap-2">
-                      {EXEC_STRATEGY_OPTIONS.map(s => {
-                        const active = execForm.allowedStrategies.includes(s.value);
+                    <div className="flex gap-2 flex-wrap">
+                      {EXEC_STRATEGY_CHIPS.map(chip => {
+                        const active = isChipActive(chip.ids);
                         return (
                           <button
-                            key={s.value}
+                            key={chip.value}
                             type="button"
-                            onClick={() => toggleExecStrategy(s.value)}
-                            className={`text-left px-3 py-2.5 rounded-lg border-2 transition-colors ${
+                            onClick={() => toggleChip(chip.ids)}
+                            className={`px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
                               active
-                                ? 'border-brand bg-brand/5 text-brand'
-                                : 'border-input-border text-text-secondary hover:border-brand/50'
+                                ? 'border-brand bg-brand/10 text-brand'
+                                : 'border-input-border text-text-secondary hover:border-brand/40'
                             }`}
                           >
-                            <div className="text-sm font-medium">{s.label}</div>
-                            <div className="text-xs text-text-muted mt-0.5">{s.desc}</div>
+                            {chip.label}
+                            <span className="ml-1 text-text-muted font-normal">{chip.desc}</span>
                           </button>
                         );
                       })}
@@ -837,8 +860,8 @@ export default function RunDetailPage() {
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <SliderInput
                       label="Max Drawdown Limit"
-                      value={execForm.maxDrawdownLimit * 100}
-                      onChange={v => setExecForm(f => ({ ...f, maxDrawdownLimit: v / 100 }))}
+                      value={execForm.max_drawdown_limit * 100}
+                      onChange={v => setExecForm(f => ({ ...f, max_drawdown_limit: v / 100 }))}
                       min={5} max={50} step={5}
                       formatValue={v => `${v.toFixed(0)}%`}
                       minLabel="5% (tight)" maxLabel="50% (loose)"
@@ -846,8 +869,8 @@ export default function RunDetailPage() {
                     />
                     <SliderInput
                       label="Aggression Level"
-                      value={execForm.aggressionLevel * 100}
-                      onChange={v => setExecForm(f => ({ ...f, aggressionLevel: v / 100 }))}
+                      value={execForm.aggression_level * 100}
+                      onChange={v => setExecForm(f => ({ ...f, aggression_level: v / 100 }))}
                       min={0} max={100} step={10}
                       formatValue={v => aggressionLabel(v / 100)}
                       minLabel="Passive" maxLabel="Aggressive"
@@ -863,8 +886,8 @@ export default function RunDetailPage() {
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                       <SliderInput
                         label="Position Size %"
-                        value={execForm.positionSizePct * 100}
-                        onChange={v => setExecForm(f => ({ ...f, positionSizePct: v / 100 }))}
+                        value={execForm.position_size_pct * 100}
+                        onChange={v => setExecForm(f => ({ ...f, position_size_pct: v / 100 }))}
                         min={5} max={100} step={5}
                         formatValue={v => `${v.toFixed(0)}%`}
                         minLabel="5%" maxLabel="100%"
@@ -873,14 +896,14 @@ export default function RunDetailPage() {
                       <TextInput
                         label="Max Position BTC"
                         placeholder="5.0"
-                        value={String(execForm.maxPositionBtc)}
-                        onChange={v => setExecForm(f => ({ ...f, maxPositionBtc: parseFloat(v) || f.maxPositionBtc }))}
+                        value={String(execForm.max_position_btc)}
+                        onChange={v => setExecForm(f => ({ ...f, max_position_btc: parseFloat(v) || f.max_position_btc }))}
                       />
                       <TextInput
                         label="Min Order Size BTC"
                         placeholder="0.1"
-                        value={String(execForm.minOrderSize)}
-                        onChange={v => setExecForm(f => ({ ...f, minOrderSize: parseFloat(v) || f.minOrderSize }))}
+                        value={String(execForm.min_order_size)}
+                        onChange={v => setExecForm(f => ({ ...f, min_order_size: parseFloat(v) || f.min_order_size }))}
                       />
                     </div>
                   </div>
@@ -890,36 +913,36 @@ export default function RunDetailPage() {
                     <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
                       Options Structure
                     </p>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      <div>
-                        <p className="text-xs text-text-muted mb-2">Expiry (DTE)</p>
-                        <div className="flex gap-2">
-                          {[7, 14, 21, 30].map(d => (
-                            <button
-                              key={d}
-                              type="button"
-                              onClick={() => setExecForm(f => ({ ...f, expiryDays: d }))}
-                              className={`flex-1 py-2 rounded-lg border-2 text-sm font-medium transition-colors ${
-                                execForm.expiryDays === d
-                                  ? 'border-brand bg-brand/5 text-brand'
-                                  : 'border-input-border text-text-secondary hover:border-brand/50'
-                              }`}
-                            >
-                              {d}d
-                            </button>
-                          ))}
-                        </div>
-                      </div>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                      <TextInput
+                        label="Min DTE"
+                        value={String(execForm.expiry_days_min)}
+                        onChange={v => setExecForm(f => ({ ...f, expiry_days_min: Math.max(1, parseInt(v) || 7) }))}
+                      />
+                      <TextInput
+                        label="Max DTE"
+                        value={String(execForm.expiry_days_max)}
+                        onChange={v => setExecForm(f => ({ ...f, expiry_days_max: Math.max(f.expiry_days_min, parseInt(v) || 7) }))}
+                      />
                       <SliderInput
-                        label="Max Margin Ratio"
-                        value={execForm.maxMarginRatio * 100}
-                        onChange={v => setExecForm(f => ({ ...f, maxMarginRatio: v / 100 }))}
-                        min={50} max={95} step={5}
-                        formatValue={v => `${v.toFixed(0)}%`}
-                        minLabel="50%" maxLabel="95%"
-                        hint="Max portfolio margin utilization before blocking new trades."
+                        label="Roll threshold (DTE)"
+                        value={execForm.roll_dte_threshold}
+                        onChange={v => setExecForm(f => ({ ...f, roll_dte_threshold: v }))}
+                        min={0} max={7} step={1}
+                        formatValue={v => v === 0 ? 'Hold' : `Roll ≤${v}d`}
+                        minLabel="Hold" maxLabel="Roll early"
+                        hint="Close positions early when DTE reaches this threshold."
                       />
                     </div>
+                    <SliderInput
+                      label="Max Margin Ratio"
+                      value={execForm.max_margin_ratio * 100}
+                      onChange={v => setExecForm(f => ({ ...f, max_margin_ratio: v / 100 }))}
+                      min={50} max={95} step={5}
+                      formatValue={v => `${v.toFixed(0)}%`}
+                      minLabel="50%" maxLabel="95%"
+                      hint="Max portfolio margin utilization before blocking new trades."
+                    />
                   </div>
 
                   {/* ── Delta management ─────────────────────────────────────── */}
@@ -930,8 +953,8 @@ export default function RunDetailPage() {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                       <SliderInput
                         label="Delta Threshold"
-                        value={execForm.deltaThreshold * 100}
-                        onChange={v => setExecForm(f => ({ ...f, deltaThreshold: v / 100 }))}
+                        value={execForm.delta_threshold * 100}
+                        onChange={v => setExecForm(f => ({ ...f, delta_threshold: v / 100 }))}
                         min={10} max={80} step={5}
                         formatValue={v => `${v.toFixed(0)}%`}
                         minLabel="10% (strict)" maxLabel="80% (loose)"
@@ -940,8 +963,8 @@ export default function RunDetailPage() {
                       <TextInput
                         label="Delta Penalty Coef"
                         placeholder="0.002"
-                        value={String(execForm.deltaPenaltyCoef)}
-                        onChange={v => setExecForm(f => ({ ...f, deltaPenaltyCoef: parseFloat(v) || f.deltaPenaltyCoef }))}
+                        value={String(execForm.delta_penalty_coef)}
+                        onChange={v => setExecForm(f => ({ ...f, delta_penalty_coef: parseFloat(v) || f.delta_penalty_coef }))}
                       />
                     </div>
                   </div>
@@ -961,20 +984,20 @@ export default function RunDetailPage() {
                         <TextInput
                           label="Risk Free Rate"
                           placeholder="0.05"
-                          value={String(execForm.riskFreeRate)}
-                          onChange={v => setExecForm(f => ({ ...f, riskFreeRate: parseFloat(v) || f.riskFreeRate }))}
+                          value={String(execForm.risk_free_rate)}
+                          onChange={v => setExecForm(f => ({ ...f, risk_free_rate: parseFloat(v) || f.risk_free_rate }))}
                         />
                         <div>
                           <p className="text-xs text-text-muted mb-2">Fast Margin</p>
                           <button
                             type="button"
-                            onClick={() => setExecForm(f => ({ ...f, fastMargin: !f.fastMargin }))}
+                            onClick={() => setExecForm(f => ({ ...f, fast_margin: !f.fast_margin }))}
                             className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                              execForm.fastMargin ? 'bg-brand' : 'bg-input-border'
+                              execForm.fast_margin ? 'bg-brand' : 'bg-input-border'
                             }`}
                           >
                             <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                              execForm.fastMargin ? 'translate-x-6' : 'translate-x-1'
+                              execForm.fast_margin ? 'translate-x-6' : 'translate-x-1'
                             }`} />
                           </button>
                           <p className="text-xs text-text-muted mt-1">
@@ -1101,7 +1124,72 @@ export default function RunDetailPage() {
 
             {/* Option breakdown */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
-              <ChartBox id="c-pie" title="Option Breakdown" height={200} />
+              <Card>
+                <p className="text-text-secondary text-xs font-semibold uppercase tracking-wider mb-4">
+                  Option Breakdown
+                </p>
+                {(() => {
+                  const s = optionSummary;
+                  const callsTotal = (s['Calls Opened']?.count ?? 0) + (s['Calls Closed']?.count ?? 0) + (s['Calls Expired']?.count ?? 0);
+                  const putsTotal  = (s['Puts Opened']?.count  ?? 0) + (s['Puts Closed']?.count  ?? 0) + (s['Puts Expired']?.count  ?? 0);
+                  const callsExpired = s['Calls Expired']?.count ?? 0;
+                  const callsClosed  = s['Calls Closed']?.count  ?? 0;
+                  const putsExpired  = s['Puts Expired']?.count  ?? 0;
+                  const putsClosed   = s['Puts Closed']?.count   ?? 0;
+
+                  function CompareBar({
+                    labelA, countA, colorA,
+                    labelB, countB, colorB,
+                  }: {
+                    labelA: string; countA: number; colorA: string;
+                    labelB: string; countB: number; colorB: string;
+                  }) {
+                    const total = countA + countB;
+                    const pctA = total ? (countA / total) * 100 : 50;
+                    const pctB = 100 - pctA;
+                    return (
+                      <div className="mb-4 last:mb-0">
+                        <div className="flex justify-between text-xs text-text-muted mb-1.5">
+                          <span>
+                            <span className="font-semibold text-text-primary">{labelA}</span>
+                            <span className="ml-1.5 font-mono">{countA}</span>
+                          </span>
+                          <span className="text-text-muted font-mono">total {total}</span>
+                          <span>
+                            <span className="font-mono mr-1.5">{countB}</span>
+                            <span className="font-semibold text-text-primary">{labelB}</span>
+                          </span>
+                        </div>
+                        <div className="flex h-5 rounded-full overflow-hidden">
+                          <div style={{ width: `${pctA}%`, backgroundColor: colorA }} className="transition-all duration-500" />
+                          <div style={{ width: `${pctB}%`, backgroundColor: colorB }} className="transition-all duration-500" />
+                        </div>
+                        <div className="flex justify-between text-[10px] text-text-muted mt-1 font-mono">
+                          <span>{pctA.toFixed(0)}%</span>
+                          <span>{pctB.toFixed(0)}%</span>
+                        </div>
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <>
+                      <CompareBar
+                        labelA="Calls" countA={callsTotal} colorA={OPTION_COLORS['Calls Opened']}
+                        labelB="Puts"  countB={putsTotal}  colorB={OPTION_COLORS['Puts Opened']}
+                      />
+                      <CompareBar
+                        labelA="Calls Expired" countA={callsExpired} colorA={OPTION_COLORS['Calls Expired']}
+                        labelB="Calls Closed"  countB={callsClosed}  colorB={OPTION_COLORS['Calls Closed']}
+                      />
+                      <CompareBar
+                        labelA="Puts Expired" countA={putsExpired} colorA={OPTION_COLORS['Puts Expired']}
+                        labelB="Puts Closed"  countB={putsClosed}  colorB={OPTION_COLORS['Puts Closed']}
+                      />
+                    </>
+                  );
+                })()}
+              </Card>
               <Card>
                 <p className="text-text-secondary text-xs font-semibold uppercase tracking-wider mb-3">
                   By Option Type
@@ -1164,18 +1252,18 @@ export default function RunDetailPage() {
                   />
                 </div>
                 <div className="flex gap-2 flex-wrap">
-                  {['All', ...uniqueTypes].map(t => (
+                  {[{ label: 'All', value: '' }, ...LOG_TYPE_TABS].map(t => (
                     <button
-                      key={t}
+                      key={t.value || 'all'}
                       type="button"
-                      onClick={() => setLogTypeFilter(t === 'All' ? '' : t)}
+                      onClick={() => setLogTypeFilter(t.value)}
                       className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors ${
-                        (t === 'All' ? !logTypeFilter : logTypeFilter === t)
+                        logTypeFilter === t.value
                           ? 'bg-brand text-white'
                           : 'bg-surface text-text-secondary hover:text-text-primary'
                       }`}
                     >
-                      {t}
+                      {t.label}
                     </button>
                   ))}
                 </div>
@@ -1212,6 +1300,33 @@ export default function RunDetailPage() {
                     </tr>
                   </thead>
                   <tbody>
+                    {/* Pinned opening-balance row — always shown regardless of filters */}
+                    {(() => {
+                      const initTs = yearActions.find(a => a.actionType === 'settlement_init')?.timestamp
+                        ?? yearActions[0]?.timestamp;
+                      const badge = ACTION_BADGE['settlement_init'];
+                      const dash = <span className="text-text-muted">—</span>;
+                      return (
+                        <tr className="bg-surface/30">
+                          <td className="px-3 py-1.5 text-text-muted whitespace-nowrap">{initTs ? fmtShort(initTs) : '—'}</td>
+                          <td className="px-3 py-1.5"><Badge text={badge.label} variant="custom" customColor={badge.color} customBgColor={badge.bg} /></td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right">{dash}</td>
+                          <td className="px-3 py-1.5 text-right font-mono text-text-muted">{n(0)}</td>
+                          <td className="px-3 py-1.5 text-right font-mono">{n(openingBalance, 4)}</td>
+                          <td className="px-3 py-1.5 text-right font-mono">{n(openingBalance, 4)}</td>
+                        </tr>
+                      );
+                    })()}
                     {filteredLog.map((a, i) => {
                       const btcP  = a.btcPrice != null ? Number(a.btcPrice) : null;
                       const style = ACTION_BADGE[a.actionType] ?? { color: 'text-text-secondary', bg: 'bg-surface', label: a.actionType };

--- a/pages/deribit-agent/agents/[id].tsx
+++ b/pages/deribit-agent/agents/[id].tsx
@@ -511,12 +511,47 @@ export default function RunDetailPage() {
     typeSummary[a.actionType].total += Number(a.pnlBtc) || 0;
   });
 
-  // cumulative pnl for the log table
+  // cumulative pnl + running open-position state for the log table
   const actionLog = (() => {
     let c = 0;
+    let openPut: string | null = null;
+    let openCall: string | null = null;
+    let openPutSize: number | null = null;
+    let openCallSize: number | null = null;
+    let openPutStrike: number | null = null;
+    let openCallStrike: number | null = null;
+
     return actions.map(a => {
       c += Number(a.pnlBtc) || 0;
-      return { ...a, cumPnl: c, equity: initCap + c };
+      const legs = parseLegs(a.instrument);
+      const qty = a.quantity != null ? Number(a.quantity) : null;
+      const t = a.actionType;
+
+      if (t === 'sell_put') {
+        openPut = legs.putInstrument;
+        openPutStrike = legs.put;
+        openPutSize = -(legs.putSize ?? qty ?? 0);
+      } else if (t === 'sell_call') {
+        openCall = legs.callInstrument;
+        openCallStrike = legs.call;
+        openCallSize = -(legs.callSize ?? qty ?? 0);
+      } else if (t === 'sell_strangle') {
+        openPut = legs.putInstrument;
+        openCall = legs.callInstrument;
+        openPutStrike = legs.put;
+        openCallStrike = legs.call;
+        openPutSize = -(legs.putSize ?? qty ?? 0);
+        openCallSize = -(legs.callSize ?? qty ?? 0);
+      } else if (t === 'close' || t.startsWith('close_')) {
+        openPut = null; openCall = null;
+        openPutSize = null; openCallSize = null;
+        openPutStrike = null; openCallStrike = null;
+      }
+
+      return {
+        ...a, cumPnl: c, equity: initCap + c,
+        openPut, openCall, openPutSize, openCallSize, openPutStrike, openCallStrike,
+      };
     });
   })();
 
@@ -539,12 +574,12 @@ export default function RunDetailPage() {
   return (
     <>
       <Head>
-        <title>Deribit Agent — Run {runId?.slice(0, 8)}</title>
+        <title>Deribit Agent — Agent {runId?.slice(0, 8)}</title>
       </Head>
 
       <Section>
         <PageHeader
-          title={runData?.name ?? 'Agent Run'}
+          title={runData?.name ?? 'Agent'}
           description={
             runData
               ? `${runData.currency} · ${runData.runType ?? 'PAPER'} · ${runData.status}`
@@ -753,6 +788,7 @@ export default function RunDetailPage() {
                           ['Delta', 'text-right'],
                           ['PnL (₿)', 'text-right'],
                           ['Cum PnL (₿)', 'text-right'],
+                          ['Margin Bal (₿)', 'text-right'],
                           ['Equity (₿)', 'text-right'],
                           ['Equity (USD)', 'text-right'],
                         ] as const
@@ -768,7 +804,6 @@ export default function RunDetailPage() {
                   </thead>
                   <tbody>
                     {filteredLog.map((a, i) => {
-                      const legs = parseLegs(a.instrument);
                       const btcP = a.btcPrice != null ? Number(a.btcPrice) : null;
                       const style = ACTION_BADGE[a.actionType] ?? {
                         color: 'text-text-secondary',
@@ -788,12 +823,11 @@ export default function RunDetailPage() {
                             />
                           </td>
                           <td className={`px-3 py-1.5 text-left font-mono ${
-                            legs.putInstrument && btcP && legs.put != null && legs.put > btcP
-                              ? 'text-error'
-                              : 'text-text-primary'
+                            a.openPut && btcP && a.openPutStrike != null && a.openPutStrike > btcP
+                              ? 'text-error' : 'text-text-primary'
                           }`}>
-                            {legs.putInstrument
-                              ? sizedInstrument(legs.putInstrument, legs.putSize ?? a.quantity, a.actionType)
+                            {a.openPut && a.openPutSize != null
+                              ? `${a.openPutSize.toFixed(1)} ${a.openPut}`
                               : '—'}
                           </td>
                           <td className="px-3 py-1.5 text-right text-text-primary font-mono">
@@ -802,12 +836,11 @@ export default function RunDetailPage() {
                               : '—'}
                           </td>
                           <td className={`px-3 py-1.5 text-left font-mono ${
-                            legs.callInstrument && btcP && legs.call != null && legs.call < btcP
-                              ? 'text-error'
-                              : 'text-text-primary'
+                            a.openCall && btcP && a.openCallStrike != null && a.openCallStrike < btcP
+                              ? 'text-error' : 'text-text-primary'
                           }`}>
-                            {legs.callInstrument
-                              ? sizedInstrument(legs.callInstrument, legs.callSize ?? a.quantity, a.actionType)
+                            {a.openCall && a.openCallSize != null
+                              ? `${a.openCallSize.toFixed(1)} ${a.openCall}`
                               : '—'}
                           </td>
                           <td className="px-3 py-1.5 text-right">
@@ -823,6 +856,9 @@ export default function RunDetailPage() {
                           </td>
                           <td className={`px-3 py-1.5 text-right font-mono ${clsColor(a.cumPnl)}`}>
                             {n(a.cumPnl)}
+                          </td>
+                          <td className="px-3 py-1.5 text-right font-mono">
+                            {a.marginBalanceBtc != null ? n(a.marginBalanceBtc, 4) : '—'}
                           </td>
                           <td className="px-3 py-1.5 text-right font-mono">{n(a.equity, 4)}</td>
                           <td className="px-3 py-1.5 text-right">

--- a/pages/deribit-agent/agents/index.tsx
+++ b/pages/deribit-agent/agents/index.tsx
@@ -5,37 +5,51 @@ import { AgentError } from '@/components/features/DeribitAgent/AgentError';
 import toast from 'react-hot-toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  faRobot, faPlus, faPlay, faPause, faStop, faChevronDown, faChevronUp, faArrowUpRightFromSquare,
+  faRobot,
+  faPlus,
+  faPlay,
+  faPause,
+  faStop,
+  faChevronDown,
+  faChevronUp,
+  faTrash,
 } from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
 import TextInput from '@/components/ui/Input/TextInput';
+import { CellEditable } from '@/components/ui/CellEditable';
 import { SelectInput } from '@/components/ui/Input/SelectInput';
 import TableHeadSearchable from '@/components/ui/Table/TableHeadSearchable';
 import TableBody from '@/components/ui/Table/TableBody';
 import TableRow from '@/components/ui/Table/TableRow';
 import TableRowEmpty from '@/components/ui/Table/TableRowEmpty';
 import {
-  useDeribitFetch, agentFetch,
-  type AgentRun, type RunType, type CreateRunBody, type ExecuteRunBody,
+  useDeribitFetch,
+  agentFetch,
+  type AgentRun,
+  type RunType,
+  type CreateRunBody,
+  type ExecuteRunBody,
   type DeribitAccount,
+  type TrainingSession,
+  type TrainedModel,
 } from '@/lib/deribit-agent/client';
 import { RUN_STATUS_BADGE, fmtDate, fmt } from '@/lib/deribit-agent/ui';
 
 const RUN_TYPE_BADGE: Record<RunType, { color: string; bg: string }> = {
   BACKTEST: { color: '#6b7280', bg: '#f3f4f6' },
-  PAPER:    { color: '#2563eb', bg: '#eff6ff' },
-  LIVE:     { color: '#dc2626', bg: '#fef2f2' },
+  PAPER: { color: '#2563eb', bg: '#eff6ff' },
+  LIVE: { color: '#dc2626', bg: '#fef2f2' },
 };
 
-const RUN_STATUSES  = ['ACTIVE', 'PAUSED', 'STOPPED', 'COMPLETED', 'ERROR'];
-const RUN_TYPES     = [
+const RUN_STATUSES = ['ACTIVE', 'PAUSED', 'STOPPED', 'COMPLETED', 'ERROR'];
+const RUN_TYPES = [
   { value: 'BACKTEST', label: 'Backtest' },
-  { value: 'PAPER',    label: 'Paper' },
-  { value: 'LIVE',     label: 'Live' },
+  { value: 'PAPER', label: 'Paper' },
+  { value: 'LIVE', label: 'Live' },
 ];
-const TABLE_HEADERS = ['Name', 'Type', 'Currency', 'Capital', 'Status', 'Created'];
+const TABLE_HEADERS = ['Name', 'Type', 'Start Capital', 'End Capital', 'Status', 'Created'];
 
 const CURRENCY_OPTIONS = [
   { value: 'BTC', label: 'BTC' },
@@ -46,12 +60,16 @@ const BLANK_RUN: CreateRunBody = {
   name: '',
   currency: 'BTC',
   runType: 'PAPER',
-  initialCapitalBtc: 0.1,
+  initialCapitalBtc: 1,
   sessionId: '',
   notes: '',
 };
 
-const BLANK_EXEC: { dataFrom: string; dataTo: string; envOverrides: ExecuteRunBody['envOverrides'] } = {
+const BLANK_EXEC: {
+  dataFrom: string;
+  dataTo: string;
+  envOverrides: ExecuteRunBody['envOverrides'];
+} = {
   dataFrom: '',
   dataTo: '',
   envOverrides: {},
@@ -68,10 +86,13 @@ export default function DeribitRunsPage() {
   const [form, setForm] = useState<CreateRunBody>(BLANK_RUN);
   const [submitting, setSubmitting] = useState(false);
 
+  const [deleting, setDeleting] = useState<string | null>(null);
   const [expandedRun, setExpandedRun] = useState<string | null>(null);
   const [execForms, setExecForms] = useState<Record<string, typeof BLANK_EXEC>>({});
   const [executing, setExecuting] = useState<Record<string, boolean>>({});
   const [actioning, setActioning] = useState<Record<string, boolean>>({});
+  const [sessionCache, setSessionCache] = useState<Record<string, TrainingSession>>({});
+  const [prefilling, setPrefilling] = useState<Set<string>>(new Set());
 
   // Table controls
   const [search, setSearch] = useState('');
@@ -82,6 +103,20 @@ export default function DeribitRunsPage() {
 
   const { data: runs, loading, error, refetch } = useDeribitFetch<AgentRun[]>('/agent/runs');
   const { data: accounts } = useDeribitFetch<DeribitAccount[]>('/deribit-account');
+  const { data: models } = useDeribitFetch<TrainedModel[]>('/training/models');
+
+  const modelOptions = [
+    { value: '', label: 'No model — paper / live without inference' },
+    ...(models ?? []).map(m => {
+      const name = /_(ppo|dqn|a2c)$/i.test(m.name) ? (m.session?.name ?? m.name) : m.name;
+      const algo = m.session?.algorithm ?? '';
+      const ccy = m.session?.currency ?? '';
+      return {
+        value: m.sessionId,
+        label: `${name}${algo ? ` — ${algo}` : ''}${ccy ? ` (${ccy})` : ''}`,
+      };
+    }),
+  ];
 
   const accountOptions = [
     { value: '', label: 'Select Deribit account…' },
@@ -95,23 +130,39 @@ export default function DeribitRunsPage() {
     let data = runs ?? [];
     if (search) {
       const q = search.toLowerCase();
-      data = data.filter(r =>
-        r.name.toLowerCase().includes(q) ||
-        r.notes?.toLowerCase().includes(q) ||
-        r.currency.toLowerCase().includes(q)
+      data = data.filter(
+        r =>
+          r.name.toLowerCase().includes(q) ||
+          r.notes?.toLowerCase().includes(q) ||
+          r.currency.toLowerCase().includes(q)
       );
     }
     if (activeStatuses.length) data = data.filter(r => activeStatuses.includes(r.status));
-    if (activeTypes.length)    data = data.filter(r => activeTypes.includes(r.runType ?? 'PAPER'));
+    if (activeTypes.length) data = data.filter(r => activeTypes.includes(r.runType ?? 'PAPER'));
     return [...data].sort((a, b) => {
       let cmp = 0;
       switch (sortCol) {
-        case 'Name':     cmp = a.name.localeCompare(b.name); break;
-        case 'Type':     cmp = (a.runType ?? 'PAPER').localeCompare(b.runType ?? 'PAPER'); break;
-        case 'Currency': cmp = a.currency.localeCompare(b.currency); break;
-        case 'Capital':  cmp = Number(a.initialCapitalBtc) - Number(b.initialCapitalBtc); break;
-        case 'Status':   cmp = a.status.localeCompare(b.status); break;
-        case 'Created':  cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(); break;
+        case 'Name':
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case 'Type':
+          cmp = (a.runType ?? 'PAPER').localeCompare(b.runType ?? 'PAPER');
+          break;
+        case 'Start Capital':
+          cmp = Number(a.initialCapitalBtc) - Number(b.initialCapitalBtc);
+          break;
+        case 'Curr. Capital': {
+          const ca = Number(a.initialCapitalBtc) + Number(a.realizedPnlBtc ?? 0);
+          const cb = Number(b.initialCapitalBtc) + Number(b.realizedPnlBtc ?? 0);
+          cmp = ca - cb;
+          break;
+        }
+        case 'Status':
+          cmp = a.status.localeCompare(b.status);
+          break;
+        case 'Created':
+          cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
       }
       return sortReverse ? -cmp : cmp;
     });
@@ -119,11 +170,13 @@ export default function DeribitRunsPage() {
 
   const handleSort = (col: string) => {
     if (sortCol === col) setSortReverse(r => !r);
-    else { setSortCol(col); setSortReverse(false); }
+    else {
+      setSortCol(col);
+      setSortReverse(false);
+    }
   };
 
-  const patchForm = (k: keyof CreateRunBody, v: unknown) =>
-    setForm(f => ({ ...f, [k]: v }));
+  const patchForm = (k: keyof CreateRunBody, v: unknown) => setForm(f => ({ ...f, [k]: v }));
 
   const createRun = async () => {
     if (!form.name || !form.currency || !form.initialCapitalBtc) {
@@ -145,7 +198,7 @@ export default function DeribitRunsPage() {
           deribitAccountId: form.deribitAccountId || undefined,
         }),
       });
-      toast.success('Run created.');
+      toast.success('Agent deployed.');
       setForm(BLANK_RUN);
       setShowCreate(false);
       refetch();
@@ -160,7 +213,9 @@ export default function DeribitRunsPage() {
     setActioning(a => ({ ...a, [id]: true }));
     try {
       await agentFetch(`/agent/runs/${id}/${action}`, { method: 'POST' });
-      toast.success(`Run ${action === 'stop' ? 'stopped' : action === 'pause' ? 'paused' : 'resumed'}.`);
+      toast.success(
+        `Agent ${action === 'stop' ? 'stopped' : action === 'pause' ? 'paused' : 'resumed'}.`
+      );
       refetch();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : `Failed to ${action} run.`);
@@ -175,21 +230,95 @@ export default function DeribitRunsPage() {
     try {
       const body: ExecuteRunBody = {};
       if (ef.dataFrom) body.dataFrom = ef.dataFrom;
-      if (ef.dataTo)   body.dataTo   = ef.dataTo;
+      if (ef.dataTo) body.dataTo = ef.dataTo;
       const cleanOv = Object.fromEntries(
         Object.entries(ef.envOverrides ?? {}).filter(([, v]) => v !== undefined)
       );
-      if (Object.keys(cleanOv).length > 0) body.envOverrides = cleanOv as ExecuteRunBody['envOverrides'];
+      if (Object.keys(cleanOv).length > 0)
+        body.envOverrides = cleanOv as ExecuteRunBody['envOverrides'];
       await agentFetch(`/agent/runs/${run.id}/execute`, {
         method: 'POST',
         body: JSON.stringify(body),
       });
-      toast.success('Execute triggered.');
+      toast.success('Agent execution queued.');
       refetch();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Execute failed.');
     } finally {
       setExecuting(e => ({ ...e, [run.id]: false }));
+    }
+  };
+
+  const deleteAgent = async (id: string) => {
+    if (!confirm('Delete this agent and all its actions? This cannot be undone.')) return;
+    setDeleting(id);
+    try {
+      await agentFetch(`/agent/runs/${id}`, { method: 'DELETE' });
+      toast.success('Agent deleted.');
+      refetch();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to delete agent.');
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  const ENV_OVERRIDE_KEYS: (keyof NonNullable<ExecuteRunBody['envOverrides']>)[] = [
+    'expiry_days',
+    'position_size_pct',
+    'max_position_btc',
+    'delta_threshold',
+    'delta_penalty_coef',
+    'max_margin_ratio',
+    'risk_free_rate',
+    'loss_multiplier',
+    'loss_threshold',
+    'capital_eff_bonus',
+  ];
+
+  const prefillExecForm = (runId: string, session: TrainingSession) => {
+    const env = (session.hyperparams?.env ?? {}) as Record<string, unknown>;
+    const overrides: Record<string, number> = {};
+    for (const k of ENV_OVERRIDE_KEYS) {
+      const v = env[k];
+      if (typeof v === 'number') overrides[k] = v;
+    }
+    setExecForms(f => ({
+      ...f,
+      [runId]: {
+        dataFrom: session.dataFrom,
+        dataTo: session.dataTo,
+        envOverrides: overrides as ExecuteRunBody['envOverrides'],
+      },
+    }));
+  };
+
+  const handleExpand = async (run: AgentRun) => {
+    const next = expandedRun === run.id ? null : run.id;
+    setExpandedRun(next);
+
+    if (!next || !run.sessionId || execForms[run.id] !== undefined) return;
+
+    const cached = sessionCache[run.sessionId];
+    if (cached) {
+      prefillExecForm(run.id, cached);
+      return;
+    }
+
+    if (prefilling.has(run.id)) return;
+    setPrefilling(p => new Set([...p, run.id]));
+    try {
+      const session = await agentFetch<TrainingSession>(`/training/sessions/${run.sessionId}`);
+      setSessionCache(c => ({ ...c, [run.sessionId!]: session }));
+      prefillExecForm(run.id, session);
+    } catch {
+      // user can fill manually
+    } finally {
+      setPrefilling(p => {
+        const n = new Set(p);
+        n.delete(run.id);
+        return n;
+      });
     }
   };
 
@@ -201,7 +330,10 @@ export default function DeribitRunsPage() {
       }
       return {
         ...f,
-        [runId]: { ...base, envOverrides: { ...(base.envOverrides ?? {}), [key]: numOrUndef(val) } },
+        [runId]: {
+          ...base,
+          envOverrides: { ...(base.envOverrides ?? {}), [key]: numOrUndef(val) },
+        },
       };
     });
   };
@@ -224,7 +356,7 @@ export default function DeribitRunsPage() {
               className="inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 transition-colors"
             >
               <FontAwesomeIcon icon={faPlus} className="w-3 h-3" />
-              New Run
+              New Agent
             </button>
           }
         />
@@ -232,7 +364,7 @@ export default function DeribitRunsPage() {
         {/* Create form */}
         {showCreate && (
           <Card className="mt-4">
-            <p className="text-sm font-semibold text-text-primary mb-4">Create Agent Run</p>
+            <p className="text-sm font-semibold text-text-primary mb-4">Deploy New Agent</p>
 
             <div className="grid grid-cols-3 gap-2 mb-4">
               {(['BACKTEST', 'PAPER', 'LIVE'] as RunType[]).map(type => (
@@ -257,43 +389,78 @@ export default function DeribitRunsPage() {
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <TextInput label="Name" placeholder="btc-ppo-run-1" value={form.name} onChange={v => patchForm('name', v)} />
-              <SelectInput label="Currency" options={CURRENCY_OPTIONS} value={form.currency} onChange={v => patchForm('currency', v)} />
-              <TextInput label="Initial Capital (BTC)" placeholder="0.1"
+              <TextInput
+                label="Name"
+                placeholder="btc-ppo-run-1"
+                value={form.name}
+                onChange={v => patchForm('name', v)}
+              />
+              <SelectInput
+                label="Currency"
+                options={CURRENCY_OPTIONS}
+                value={form.currency}
+                onChange={v => patchForm('currency', v)}
+              />
+              <TextInput
+                label="Initial Capital (BTC)"
+                placeholder="0.1"
                 value={String(form.initialCapitalBtc)}
-                onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)} />
-              <TextInput label="Session ID (optional)" placeholder="Trained model session"
-                value={form.sessionId ?? ''} onChange={v => patchForm('sessionId', v)} />
+                onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)}
+              />
+              <SelectInput
+                label="Model (optional)"
+                options={modelOptions}
+                value={form.sessionId ?? ''}
+                onChange={v => patchForm('sessionId', v)}
+              />
 
               {form.runType === 'LIVE' && (
                 <div className="md:col-span-2">
-                  <SelectInput label="Deribit Account" options={accountOptions}
-                    value={form.deribitAccountId ?? ''} onChange={v => patchForm('deribitAccountId', v)} />
+                  <SelectInput
+                    label="Deribit Account"
+                    options={accountOptions}
+                    value={form.deribitAccountId ?? ''}
+                    onChange={v => patchForm('deribitAccountId', v)}
+                  />
                   {!accounts?.length && (
-                    <p className="text-xs text-error mt-1.5">No Deribit accounts configured. Add one in Settings first.</p>
+                    <p className="text-xs text-error mt-1.5">
+                      No Deribit accounts configured. Add one in Settings first.
+                    </p>
                   )}
                 </div>
               )}
 
-              <TextInput label="Notes (optional)" placeholder="Any notes..."
-                value={form.notes ?? ''} onChange={v => patchForm('notes', v)} />
+              <TextInput
+                label="Notes (optional)"
+                placeholder="Any notes..."
+                value={form.notes ?? ''}
+                onChange={v => patchForm('notes', v)}
+              />
             </div>
 
             {form.runType === 'LIVE' && (
               <div className="mt-3 bg-error/5 border border-error/20 rounded-lg px-4 py-2.5">
                 <p className="text-xs text-error font-medium">
-                  Live mode will place real orders on your Deribit account. Ensure you have reviewed the model before running.
+                  Live mode will place real orders on your Deribit account. Ensure you have reviewed
+                  the model before running.
                 </p>
               </div>
             )}
 
             <div className="flex gap-3 mt-4">
-              <button type="button" onClick={createRun} disabled={submitting}
-                className="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors">
-                {submitting ? 'Creating…' : 'Create Run'}
+              <button
+                type="button"
+                onClick={createRun}
+                disabled={submitting}
+                className="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
+              >
+                {submitting ? 'Deploying…' : 'Deploy'}
               </button>
-              <button type="button" onClick={() => setShowCreate(false)}
-                className="px-4 py-2 rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors">
+              <button
+                type="button"
+                onClick={() => setShowCreate(false)}
+                className="px-4 py-2 rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
                 Cancel
               </button>
             </div>
@@ -304,7 +471,9 @@ export default function DeribitRunsPage() {
         <div className="mt-6">
           {loading ? (
             <div className="space-y-2">
-              {[1, 2, 3].map(i => <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />)}
+              {[1, 2, 3].map(i => (
+                <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />
+              ))}
             </div>
           ) : error ? (
             <AgentError message={error} onRetry={refetch} />
@@ -335,16 +504,20 @@ export default function DeribitRunsPage() {
               <TableBody>
                 {visibleRuns.length === 0 ? (
                   <TableRowEmpty>
-                    {runs?.length ? 'No runs match your filters.' : 'No runs yet.'}
+                    {runs?.length ? 'No agents match your filters.' : 'No agents yet.'}
                   </TableRowEmpty>
                 ) : (
-                  visibleRuns.map(run => {
+                  (visibleRuns.map(run => {
                     const isExpanded = expandedRun === run.id;
                     const ef = execForms[run.id] ?? BLANK_EXEC;
                     const ov = ef.envOverrides ?? {};
                     const isExec = executing[run.id];
                     const isAct = actioning[run.id];
+                    const isDel = deleting === run.id;
                     const rt = run.runType ?? 'PAPER';
+                    const currCapital =
+                      Number(run.initialCapitalBtc) + Number(run.realizedPnlBtc ?? 0);
+                    const capitalDelta = currCapital - Number(run.initialCapitalBtc);
 
                     return (
                       <div key={run.id}>
@@ -352,56 +525,120 @@ export default function DeribitRunsPage() {
                           colSpan={TABLE_HEADERS.length}
                           headers={TABLE_HEADERS}
                           tab={sortCol}
+                          onClick={() => router.push(`/deribit-agent/agents/${run.id}`)}
                           actionCol={
                             <div className="flex items-center justify-end gap-1">
                               {run.status === 'ACTIVE' && (
-                                <button type="button" disabled={isAct} onClick={() => runAction(run.id, 'pause')}
-                                  title="Pause" className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50">
+                                <button
+                                  type="button"
+                                  disabled={isAct}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    runAction(run.id, 'pause');
+                                  }}
+                                  title="Pause"
+                                  className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50"
+                                >
                                   <FontAwesomeIcon icon={faPause} className="w-3 h-3" />
                                 </button>
                               )}
                               {run.status === 'PAUSED' && (
-                                <button type="button" disabled={isAct} onClick={() => runAction(run.id, 'resume')}
-                                  title="Resume" className="p-1.5 rounded text-success hover:bg-success/20 transition-colors disabled:opacity-50">
+                                <button
+                                  type="button"
+                                  disabled={isAct}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    runAction(run.id, 'resume');
+                                  }}
+                                  title="Resume"
+                                  className="p-1.5 rounded text-success hover:bg-success/20 transition-colors disabled:opacity-50"
+                                >
                                   <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
                                 </button>
                               )}
                               {(run.status === 'ACTIVE' || run.status === 'PAUSED') && (
-                                <button type="button" disabled={isAct} onClick={() => runAction(run.id, 'stop')}
-                                  title="Stop" className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50">
+                                <button
+                                  type="button"
+                                  disabled={isAct}
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    runAction(run.id, 'stop');
+                                  }}
+                                  title="Stop"
+                                  className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
+                                >
                                   <FontAwesomeIcon icon={faStop} className="w-3 h-3" />
                                 </button>
                               )}
-                              <button type="button" onClick={() => router.push(`/deribit-agent/agents/${run.id}`)}
-                                title="View detail" className="p-1.5 rounded text-text-secondary hover:text-brand transition-colors">
-                                <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="w-3 h-3" />
+                              <button
+                                type="button"
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  handleExpand(run);
+                                }}
+                                title="Execute"
+                                className="p-1.5 rounded text-text-secondary hover:text-brand transition-colors"
+                              >
+                                <FontAwesomeIcon
+                                  icon={isExpanded ? faChevronUp : faChevronDown}
+                                  className="w-3 h-3"
+                                />
                               </button>
-                              <button type="button" onClick={() => setExpandedRun(isExpanded ? null : run.id)}
-                                title="Execute" className="p-1.5 rounded text-text-secondary hover:text-brand transition-colors">
-                                <FontAwesomeIcon icon={isExpanded ? faChevronUp : faChevronDown} className="w-3 h-3" />
+                              <button
+                                type="button"
+                                disabled={isDel}
+                                onClick={e => {
+                                  e.stopPropagation();
+                                  deleteAgent(run.id);
+                                }}
+                                title="Delete"
+                                className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
+                              >
+                                <FontAwesomeIcon icon={faTrash} className="w-3 h-3" />
                               </button>
                             </div>
                           }
                         >
                           {/* Name */}
-                          <div className="text-left">
-                            <div className="font-medium text-text-primary">{run.name}</div>
-                            {run.notes && <div className="text-text-muted text-xs">{run.notes}</div>}
+                          <div className="text-left" onClick={e => e.stopPropagation()}>
+                            <CellEditable
+                              value={run.name}
+                              onSave={async v => {
+                                await agentFetch(`/agent/runs/${run.id}`, {
+                                  method: 'PATCH',
+                                  body: JSON.stringify({ name: v }),
+                                });
+                                refetch();
+                              }}
+                            />
+                            {run.notes && (
+                              <div className="text-text-muted text-xs mt-0.5">{run.notes}</div>
+                            )}
                           </div>
                           {/* Type */}
                           <span>
-                            <Badge text={rt} variant="custom"
+                            <Badge
+                              text={rt}
+                              variant="custom"
                               customColor={RUN_TYPE_BADGE[rt].color}
                               customBgColor={RUN_TYPE_BADGE[rt].bg}
                             />
                           </span>
-                          {/* Currency */}
-                          <span className="text-text-secondary">{run.currency}</span>
-                          {/* Capital */}
-                          <span className="font-mono text-text-primary">{fmt(run.initialCapitalBtc)} BTC</span>
+                          {/* Start Capital */}
+                          <span className="font-mono text-text-secondary">
+                            {fmt(run.initialCapitalBtc, 4)} {run.currency}
+                          </span>
+                          {/* Curr. Capital */}
+                          <span
+                            className={`font-mono ${capitalDelta > 0 ? 'text-success' : capitalDelta < 0 ? 'text-error' : 'text-text-secondary'}`}
+                          >
+                            {fmt(currCapital, 4)} {run.currency}
+                          </span>
                           {/* Status */}
                           <span>
-                            <Badge text={run.status} variant="custom"
+                            <Badge
+                              text={run.status}
+                              variant="custom"
                               customColor={RUN_STATUS_BADGE[run.status].color}
                               customBgColor={RUN_STATUS_BADGE[run.status].bg}
                             />
@@ -413,12 +650,22 @@ export default function DeribitRunsPage() {
                         {/* Execute panel */}
                         {isExpanded && (
                           <div className="border-t border-table-alt px-6 py-4 bg-surface/20">
-                            <p className="text-sm font-semibold text-text-primary mb-4">Execute Run</p>
+                            <p className="text-sm font-semibold text-text-primary mb-4">
+                              Execute Agent
+                            </p>
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              <TextInput label="Data From (ISO, optional)" placeholder="2024-01-01T00:00:00Z"
-                                value={ef.dataFrom} onChange={v => patchExec(run.id, 'dataFrom', v)} />
-                              <TextInput label="Data To (ISO, optional)" placeholder="2024-12-31T23:59:59Z"
-                                value={ef.dataTo} onChange={v => patchExec(run.id, 'dataTo', v)} />
+                              <TextInput
+                                label="Data From (ISO, optional)"
+                                placeholder="2024-01-01T00:00:00Z"
+                                value={ef.dataFrom}
+                                onChange={v => patchExec(run.id, 'dataFrom', v)}
+                              />
+                              <TextInput
+                                label="Data To (ISO, optional)"
+                                placeholder="2024-12-31T23:59:59Z"
+                                value={ef.dataTo}
+                                onChange={v => patchExec(run.id, 'dataTo', v)}
+                              />
                             </div>
                             <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mt-4 mb-3">
                               Env Overrides (optional)
@@ -426,29 +673,37 @@ export default function DeribitRunsPage() {
                             <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
                               {(
                                 [
-                                  ['expiry_days',        'Expiry Days'],
-                                  ['position_size_pct',  'Position Size %'],
-                                  ['max_position_btc',   'Max Position BTC'],
-                                  ['delta_threshold',    'Delta Threshold'],
+                                  ['expiry_days', 'Expiry Days'],
+                                  ['position_size_pct', 'Position Size %'],
+                                  ['max_position_btc', 'Max Position BTC'],
+                                  ['delta_threshold', 'Delta Threshold'],
                                   ['delta_penalty_coef', 'Delta Penalty Coef'],
-                                  ['max_margin_ratio',   'Max Margin Ratio'],
+                                  ['max_margin_ratio', 'Max Margin Ratio'],
                                 ] as const
                               ).map(([key, label]) => (
-                                <TextInput key={key} label={label} placeholder="—"
+                                <TextInput
+                                  key={key}
+                                  label={label}
+                                  placeholder="—"
                                   value={ov[key] !== undefined ? String(ov[key]) : ''}
-                                  onChange={v => patchExec(run.id, key, v)} />
+                                  onChange={v => patchExec(run.id, key, v)}
+                                />
                               ))}
                             </div>
-                            <button type="button" disabled={isExec} onClick={() => executeRun(run)}
-                              className="mt-4 inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors">
+                            <button
+                              type="button"
+                              disabled={isExec}
+                              onClick={() => executeRun(run)}
+                              className="mt-4 inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
+                            >
                               <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
-                              {isExec ? 'Executing…' : 'Execute'}
+                              {isExec ? 'Queuing…' : 'Execute'}
                             </button>
                           </div>
                         )}
                       </div>
                     );
-                  }) as any
+                  }) as any)
                 )}
               </TableBody>
             </div>

--- a/pages/deribit-agent/agents/index.tsx
+++ b/pages/deribit-agent/agents/index.tsx
@@ -153,8 +153,9 @@ export default function DeribitRunsPage() {
   const patchForm = (k: keyof CreateRunBody, v: unknown) => setForm(f => ({ ...f, [k]: v }));
 
   const createRun = async () => {
-    if (!form.name || !form.initialCapitalBtc) {
-      toast.error('Name and initial capital are required.');
+    const needsCapital = form.runType !== 'LIVE';
+    if (!form.name || (needsCapital && !form.initialCapitalBtc)) {
+      toast.error(needsCapital ? 'Name and initial capital are required.' : 'Name is required.');
       return;
     }
     if (form.runType === 'LIVE' && !form.deribitAccountId) {
@@ -268,12 +269,20 @@ export default function DeribitRunsPage() {
                 value={form.name}
                 onChange={v => patchForm('name', v)}
               />
-              <TextInput
-                label="Initial Capital (BTC)"
-                placeholder="1.0"
-                value={String(form.initialCapitalBtc)}
-                onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)}
-              />
+              {form.runType !== 'LIVE' && (
+                <TextInput
+                  label="Initial Capital (BTC)"
+                  placeholder="1.0"
+                  value={String(form.initialCapitalBtc)}
+                  onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)}
+                />
+              )}
+              {form.runType === 'LIVE' && (
+                <div className="flex flex-col justify-center px-3 py-2 rounded-lg border border-input-border bg-surface/50">
+                  <span className="text-xs text-input-label mb-0.5">Initial Capital</span>
+                  <span className="text-sm text-text-secondary">Fetched from Deribit account at start</span>
+                </div>
+              )}
               <SelectInput
                 label="Currency"
                 options={CURRENCY_OPTIONS}

--- a/pages/deribit-agent/agents/index.tsx
+++ b/pages/deribit-agent/agents/index.tsx
@@ -10,8 +10,6 @@ import {
   faPlay,
   faPause,
   faStop,
-  faChevronDown,
-  faChevronUp,
   faTrash,
 } from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
@@ -30,9 +28,7 @@ import {
   type AgentRun,
   type RunType,
   type CreateRunBody,
-  type ExecuteRunBody,
   type DeribitAccount,
-  type TrainingSession,
   type TrainedModel,
 } from '@/lib/deribit-agent/client';
 import { RUN_STATUS_BADGE, fmtDate, fmt } from '@/lib/deribit-agent/ui';
@@ -62,37 +58,15 @@ const BLANK_RUN: CreateRunBody = {
   runType: 'PAPER',
   initialCapitalBtc: 1,
   sessionId: '',
-  notes: '',
 };
-
-const BLANK_EXEC: {
-  dataFrom: string;
-  dataTo: string;
-  envOverrides: ExecuteRunBody['envOverrides'];
-} = {
-  dataFrom: '',
-  dataTo: '',
-  envOverrides: {},
-};
-
-function numOrUndef(s: string): number | undefined {
-  const n = parseFloat(s);
-  return isNaN(n) ? undefined : n;
-}
 
 export default function DeribitRunsPage() {
   const router = useRouter();
   const [showCreate, setShowCreate] = useState(false);
   const [form, setForm] = useState<CreateRunBody>(BLANK_RUN);
   const [submitting, setSubmitting] = useState(false);
-
   const [deleting, setDeleting] = useState<string | null>(null);
-  const [expandedRun, setExpandedRun] = useState<string | null>(null);
-  const [execForms, setExecForms] = useState<Record<string, typeof BLANK_EXEC>>({});
-  const [executing, setExecuting] = useState<Record<string, boolean>>({});
   const [actioning, setActioning] = useState<Record<string, boolean>>({});
-  const [sessionCache, setSessionCache] = useState<Record<string, TrainingSession>>({});
-  const [prefilling, setPrefilling] = useState<Set<string>>(new Set());
 
   // Table controls
   const [search, setSearch] = useState('');
@@ -106,7 +80,7 @@ export default function DeribitRunsPage() {
   const { data: models } = useDeribitFetch<TrainedModel[]>('/training/models');
 
   const modelOptions = [
-    { value: '', label: 'No model — paper / live without inference' },
+    { value: '', label: 'No model' },
     ...(models ?? []).map(m => {
       const name = /_(ppo|dqn|a2c)$/i.test(m.name) ? (m.session?.name ?? m.name) : m.name;
       const algo = m.session?.algorithm ?? '';
@@ -151,7 +125,7 @@ export default function DeribitRunsPage() {
         case 'Start Capital':
           cmp = Number(a.initialCapitalBtc) - Number(b.initialCapitalBtc);
           break;
-        case 'Curr. Capital': {
+        case 'End Capital': {
           const ca = Number(a.initialCapitalBtc) + Number(a.realizedPnlBtc ?? 0);
           const cb = Number(b.initialCapitalBtc) + Number(b.realizedPnlBtc ?? 0);
           cmp = ca - cb;
@@ -179,8 +153,8 @@ export default function DeribitRunsPage() {
   const patchForm = (k: keyof CreateRunBody, v: unknown) => setForm(f => ({ ...f, [k]: v }));
 
   const createRun = async () => {
-    if (!form.name || !form.currency || !form.initialCapitalBtc) {
-      toast.error('Name, currency and capital are required.');
+    if (!form.name || !form.initialCapitalBtc) {
+      toast.error('Name and initial capital are required.');
       return;
     }
     if (form.runType === 'LIVE' && !form.deribitAccountId) {
@@ -189,21 +163,21 @@ export default function DeribitRunsPage() {
     }
     setSubmitting(true);
     try {
-      await agentFetch('/agent/runs', {
+      const created = await agentFetch<AgentRun>('/agent/runs', {
         method: 'POST',
         body: JSON.stringify({
           ...form,
           sessionId: form.sessionId || undefined,
-          notes: form.notes || undefined,
           deribitAccountId: form.deribitAccountId || undefined,
         }),
       });
-      toast.success('Agent deployed.');
+      toast.success('Agent created.');
       setForm(BLANK_RUN);
       setShowCreate(false);
       refetch();
+      router.push(`/deribit-agent/agents/${created.id}`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to create run.');
+      toast.error(e instanceof Error ? e.message : 'Failed to create agent.');
     } finally {
       setSubmitting(false);
     }
@@ -213,39 +187,12 @@ export default function DeribitRunsPage() {
     setActioning(a => ({ ...a, [id]: true }));
     try {
       await agentFetch(`/agent/runs/${id}/${action}`, { method: 'POST' });
-      toast.success(
-        `Agent ${action === 'stop' ? 'stopped' : action === 'pause' ? 'paused' : 'resumed'}.`
-      );
+      toast.success(`Agent ${action === 'stop' ? 'stopped' : action === 'pause' ? 'paused' : 'resumed'}.`);
       refetch();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : `Failed to ${action} run.`);
     } finally {
       setActioning(a => ({ ...a, [id]: false }));
-    }
-  };
-
-  const executeRun = async (run: AgentRun) => {
-    const ef = execForms[run.id] ?? BLANK_EXEC;
-    setExecuting(e => ({ ...e, [run.id]: true }));
-    try {
-      const body: ExecuteRunBody = {};
-      if (ef.dataFrom) body.dataFrom = ef.dataFrom;
-      if (ef.dataTo) body.dataTo = ef.dataTo;
-      const cleanOv = Object.fromEntries(
-        Object.entries(ef.envOverrides ?? {}).filter(([, v]) => v !== undefined)
-      );
-      if (Object.keys(cleanOv).length > 0)
-        body.envOverrides = cleanOv as ExecuteRunBody['envOverrides'];
-      await agentFetch(`/agent/runs/${run.id}/execute`, {
-        method: 'POST',
-        body: JSON.stringify(body),
-      });
-      toast.success('Agent execution queued.');
-      refetch();
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Execute failed.');
-    } finally {
-      setExecuting(e => ({ ...e, [run.id]: false }));
     }
   };
 
@@ -261,81 +208,6 @@ export default function DeribitRunsPage() {
     } finally {
       setDeleting(null);
     }
-  };
-
-  const ENV_OVERRIDE_KEYS: (keyof NonNullable<ExecuteRunBody['envOverrides']>)[] = [
-    'expiry_days',
-    'position_size_pct',
-    'max_position_btc',
-    'delta_threshold',
-    'delta_penalty_coef',
-    'max_margin_ratio',
-    'risk_free_rate',
-    'loss_multiplier',
-    'loss_threshold',
-    'capital_eff_bonus',
-  ];
-
-  const prefillExecForm = (runId: string, session: TrainingSession) => {
-    const env = (session.hyperparams?.env ?? {}) as Record<string, unknown>;
-    const overrides: Record<string, number> = {};
-    for (const k of ENV_OVERRIDE_KEYS) {
-      const v = env[k];
-      if (typeof v === 'number') overrides[k] = v;
-    }
-    setExecForms(f => ({
-      ...f,
-      [runId]: {
-        dataFrom: session.dataFrom,
-        dataTo: session.dataTo,
-        envOverrides: overrides as ExecuteRunBody['envOverrides'],
-      },
-    }));
-  };
-
-  const handleExpand = async (run: AgentRun) => {
-    const next = expandedRun === run.id ? null : run.id;
-    setExpandedRun(next);
-
-    if (!next || !run.sessionId || execForms[run.id] !== undefined) return;
-
-    const cached = sessionCache[run.sessionId];
-    if (cached) {
-      prefillExecForm(run.id, cached);
-      return;
-    }
-
-    if (prefilling.has(run.id)) return;
-    setPrefilling(p => new Set([...p, run.id]));
-    try {
-      const session = await agentFetch<TrainingSession>(`/training/sessions/${run.sessionId}`);
-      setSessionCache(c => ({ ...c, [run.sessionId!]: session }));
-      prefillExecForm(run.id, session);
-    } catch {
-      // user can fill manually
-    } finally {
-      setPrefilling(p => {
-        const n = new Set(p);
-        n.delete(run.id);
-        return n;
-      });
-    }
-  };
-
-  const patchExec = (runId: string, key: string, val: string) => {
-    setExecForms(f => {
-      const base = f[runId] ?? { ...BLANK_EXEC, envOverrides: {} };
-      if (key === 'dataFrom' || key === 'dataTo') {
-        return { ...f, [runId]: { ...base, [key]: val } };
-      }
-      return {
-        ...f,
-        [runId]: {
-          ...base,
-          envOverrides: { ...(base.envOverrides ?? {}), [key]: numOrUndef(val) },
-        },
-      };
-    });
   };
 
   return (
@@ -364,8 +236,9 @@ export default function DeribitRunsPage() {
         {/* Create form */}
         {showCreate && (
           <Card className="mt-4">
-            <p className="text-sm font-semibold text-text-primary mb-4">Deploy New Agent</p>
+            <p className="text-sm font-semibold text-text-primary mb-4">New Agent</p>
 
+            {/* Run type */}
             <div className="grid grid-cols-3 gap-2 mb-4">
               {(['BACKTEST', 'PAPER', 'LIVE'] as RunType[]).map(type => (
                 <button
@@ -395,17 +268,17 @@ export default function DeribitRunsPage() {
                 value={form.name}
                 onChange={v => patchForm('name', v)}
               />
+              <TextInput
+                label="Initial Capital (BTC)"
+                placeholder="1.0"
+                value={String(form.initialCapitalBtc)}
+                onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)}
+              />
               <SelectInput
                 label="Currency"
                 options={CURRENCY_OPTIONS}
                 value={form.currency}
                 onChange={v => patchForm('currency', v)}
-              />
-              <TextInput
-                label="Initial Capital (BTC)"
-                placeholder="0.1"
-                value={String(form.initialCapitalBtc)}
-                onChange={v => patchForm('initialCapitalBtc', parseFloat(v) || 0)}
               />
               <SelectInput
                 label="Model (optional)"
@@ -413,7 +286,6 @@ export default function DeribitRunsPage() {
                 value={form.sessionId ?? ''}
                 onChange={v => patchForm('sessionId', v)}
               />
-
               {form.runType === 'LIVE' && (
                 <div className="md:col-span-2">
                   <SelectInput
@@ -429,20 +301,12 @@ export default function DeribitRunsPage() {
                   )}
                 </div>
               )}
-
-              <TextInput
-                label="Notes (optional)"
-                placeholder="Any notes..."
-                value={form.notes ?? ''}
-                onChange={v => patchForm('notes', v)}
-              />
             </div>
 
             {form.runType === 'LIVE' && (
               <div className="mt-3 bg-error/5 border border-error/20 rounded-lg px-4 py-2.5">
                 <p className="text-xs text-error font-medium">
-                  Live mode will place real orders on your Deribit account. Ensure you have reviewed
-                  the model before running.
+                  Live mode places real orders on your Deribit account. Review the model before running.
                 </p>
               </div>
             )}
@@ -454,7 +318,7 @@ export default function DeribitRunsPage() {
                 disabled={submitting}
                 className="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
               >
-                {submitting ? 'Deploying…' : 'Deploy'}
+                {submitting ? 'Creating…' : 'Create Agent'}
               </button>
               <button
                 type="button"
@@ -480,7 +344,7 @@ export default function DeribitRunsPage() {
           ) : (
             <div className="rounded-lg overflow-hidden border border-table-alt">
               <TableHeadSearchable
-                searchPlaceholder="Search by name, notes, currency…"
+                searchPlaceholder="Search by name, currency…"
                 searchValue={search}
                 onSearchChange={setSearch}
                 hideMyWallet
@@ -508,10 +372,6 @@ export default function DeribitRunsPage() {
                   </TableRowEmpty>
                 ) : (
                   (visibleRuns.map(run => {
-                    const isExpanded = expandedRun === run.id;
-                    const ef = execForms[run.id] ?? BLANK_EXEC;
-                    const ov = ef.envOverrides ?? {};
-                    const isExec = executing[run.id];
                     const isAct = actioning[run.id];
                     const isDel = deleting === run.id;
                     const rt = run.runType ?? 'PAPER';
@@ -520,188 +380,106 @@ export default function DeribitRunsPage() {
                     const capitalDelta = currCapital - Number(run.initialCapitalBtc);
 
                     return (
-                      <div key={run.id}>
-                        <TableRow
-                          colSpan={TABLE_HEADERS.length}
-                          headers={TABLE_HEADERS}
-                          tab={sortCol}
-                          onClick={() => router.push(`/deribit-agent/agents/${run.id}`)}
-                          actionCol={
-                            <div className="flex items-center justify-end gap-1">
-                              {run.status === 'ACTIVE' && (
-                                <button
-                                  type="button"
-                                  disabled={isAct}
-                                  onClick={e => {
-                                    e.stopPropagation();
-                                    runAction(run.id, 'pause');
-                                  }}
-                                  title="Pause"
-                                  className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50"
-                                >
-                                  <FontAwesomeIcon icon={faPause} className="w-3 h-3" />
-                                </button>
-                              )}
-                              {run.status === 'PAUSED' && (
-                                <button
-                                  type="button"
-                                  disabled={isAct}
-                                  onClick={e => {
-                                    e.stopPropagation();
-                                    runAction(run.id, 'resume');
-                                  }}
-                                  title="Resume"
-                                  className="p-1.5 rounded text-success hover:bg-success/20 transition-colors disabled:opacity-50"
-                                >
-                                  <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
-                                </button>
-                              )}
-                              {(run.status === 'ACTIVE' || run.status === 'PAUSED') && (
-                                <button
-                                  type="button"
-                                  disabled={isAct}
-                                  onClick={e => {
-                                    e.stopPropagation();
-                                    runAction(run.id, 'stop');
-                                  }}
-                                  title="Stop"
-                                  className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
-                                >
-                                  <FontAwesomeIcon icon={faStop} className="w-3 h-3" />
-                                </button>
-                              )}
+                      <TableRow
+                        key={run.id}
+                        colSpan={TABLE_HEADERS.length}
+                        headers={TABLE_HEADERS}
+                        tab={sortCol}
+                        onClick={() => router.push(`/deribit-agent/agents/${run.id}`)}
+                        actionCol={
+                          <div className="flex items-center justify-end gap-1">
+                            {run.status === 'ACTIVE' && (
                               <button
                                 type="button"
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  handleExpand(run);
-                                }}
-                                title="Execute"
-                                className="p-1.5 rounded text-text-secondary hover:text-brand transition-colors"
+                                disabled={isAct}
+                                onClick={e => { e.stopPropagation(); runAction(run.id, 'pause'); }}
+                                title="Pause"
+                                className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50"
                               >
-                                <FontAwesomeIcon
-                                  icon={isExpanded ? faChevronUp : faChevronDown}
-                                  className="w-3 h-3"
-                                />
+                                <FontAwesomeIcon icon={faPause} className="w-3 h-3" />
                               </button>
+                            )}
+                            {run.status === 'PAUSED' && (
                               <button
                                 type="button"
-                                disabled={isDel}
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  deleteAgent(run.id);
-                                }}
-                                title="Delete"
+                                disabled={isAct}
+                                onClick={e => { e.stopPropagation(); runAction(run.id, 'resume'); }}
+                                title="Resume"
+                                className="p-1.5 rounded text-success hover:bg-success/20 transition-colors disabled:opacity-50"
+                              >
+                                <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
+                              </button>
+                            )}
+                            {(run.status === 'ACTIVE' || run.status === 'PAUSED') && (
+                              <button
+                                type="button"
+                                disabled={isAct}
+                                onClick={e => { e.stopPropagation(); runAction(run.id, 'stop'); }}
+                                title="Stop"
                                 className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
                               >
-                                <FontAwesomeIcon icon={faTrash} className="w-3 h-3" />
+                                <FontAwesomeIcon icon={faStop} className="w-3 h-3" />
                               </button>
-                            </div>
-                          }
-                        >
-                          {/* Name */}
-                          <div className="text-left" onClick={e => e.stopPropagation()}>
-                            <CellEditable
-                              value={run.name}
-                              onSave={async v => {
-                                await agentFetch(`/agent/runs/${run.id}`, {
-                                  method: 'PATCH',
-                                  body: JSON.stringify({ name: v }),
-                                });
-                                refetch();
-                              }}
-                            />
-                            {run.notes && (
-                              <div className="text-text-muted text-xs mt-0.5">{run.notes}</div>
                             )}
-                          </div>
-                          {/* Type */}
-                          <span>
-                            <Badge
-                              text={rt}
-                              variant="custom"
-                              customColor={RUN_TYPE_BADGE[rt].color}
-                              customBgColor={RUN_TYPE_BADGE[rt].bg}
-                            />
-                          </span>
-                          {/* Start Capital */}
-                          <span className="font-mono text-text-secondary">
-                            {fmt(run.initialCapitalBtc, 4)} {run.currency}
-                          </span>
-                          {/* Curr. Capital */}
-                          <span
-                            className={`font-mono ${capitalDelta > 0 ? 'text-success' : capitalDelta < 0 ? 'text-error' : 'text-text-secondary'}`}
-                          >
-                            {fmt(currCapital, 4)} {run.currency}
-                          </span>
-                          {/* Status */}
-                          <span>
-                            <Badge
-                              text={run.status}
-                              variant="custom"
-                              customColor={RUN_STATUS_BADGE[run.status].color}
-                              customBgColor={RUN_STATUS_BADGE[run.status].bg}
-                            />
-                          </span>
-                          {/* Created */}
-                          <span className="text-text-muted">{fmtDate(run.createdAt)}</span>
-                        </TableRow>
-
-                        {/* Execute panel */}
-                        {isExpanded && (
-                          <div className="border-t border-table-alt px-6 py-4 bg-surface/20">
-                            <p className="text-sm font-semibold text-text-primary mb-4">
-                              Execute Agent
-                            </p>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                              <TextInput
-                                label="Data From (ISO, optional)"
-                                placeholder="2024-01-01T00:00:00Z"
-                                value={ef.dataFrom}
-                                onChange={v => patchExec(run.id, 'dataFrom', v)}
-                              />
-                              <TextInput
-                                label="Data To (ISO, optional)"
-                                placeholder="2024-12-31T23:59:59Z"
-                                value={ef.dataTo}
-                                onChange={v => patchExec(run.id, 'dataTo', v)}
-                              />
-                            </div>
-                            <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mt-4 mb-3">
-                              Env Overrides (optional)
-                            </p>
-                            <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-                              {(
-                                [
-                                  ['expiry_days', 'Expiry Days'],
-                                  ['position_size_pct', 'Position Size %'],
-                                  ['max_position_btc', 'Max Position BTC'],
-                                  ['delta_threshold', 'Delta Threshold'],
-                                  ['delta_penalty_coef', 'Delta Penalty Coef'],
-                                  ['max_margin_ratio', 'Max Margin Ratio'],
-                                ] as const
-                              ).map(([key, label]) => (
-                                <TextInput
-                                  key={key}
-                                  label={label}
-                                  placeholder="—"
-                                  value={ov[key] !== undefined ? String(ov[key]) : ''}
-                                  onChange={v => patchExec(run.id, key, v)}
-                                />
-                              ))}
-                            </div>
                             <button
                               type="button"
-                              disabled={isExec}
-                              onClick={() => executeRun(run)}
-                              className="mt-4 inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
+                              disabled={isDel}
+                              onClick={e => { e.stopPropagation(); deleteAgent(run.id); }}
+                              title="Delete"
+                              className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
                             >
-                              <FontAwesomeIcon icon={faPlay} className="w-3 h-3" />
-                              {isExec ? 'Queuing…' : 'Execute'}
+                              <FontAwesomeIcon icon={faTrash} className="w-3 h-3" />
                             </button>
                           </div>
-                        )}
-                      </div>
+                        }
+                      >
+                        {/* Name */}
+                        <div className="text-left" onClick={e => e.stopPropagation()}>
+                          <CellEditable
+                            value={run.name}
+                            onSave={async v => {
+                              await agentFetch(`/agent/runs/${run.id}`, {
+                                method: 'PATCH',
+                                body: JSON.stringify({ name: v }),
+                              });
+                              refetch();
+                            }}
+                          />
+                          {run.notes && (
+                            <div className="text-text-muted text-xs mt-0.5">{run.notes}</div>
+                          )}
+                        </div>
+                        {/* Type */}
+                        <span>
+                          <Badge
+                            text={rt}
+                            variant="custom"
+                            customColor={RUN_TYPE_BADGE[rt].color}
+                            customBgColor={RUN_TYPE_BADGE[rt].bg}
+                          />
+                        </span>
+                        {/* Start Capital */}
+                        <span className="font-mono text-text-secondary">
+                          {fmt(run.initialCapitalBtc, 4)} {run.currency}
+                        </span>
+                        {/* End Capital */}
+                        <span
+                          className={`font-mono ${capitalDelta > 0 ? 'text-success' : capitalDelta < 0 ? 'text-error' : 'text-text-secondary'}`}
+                        >
+                          {fmt(currCapital, 4)} {run.currency}
+                        </span>
+                        {/* Status */}
+                        <span>
+                          <Badge
+                            text={run.status}
+                            variant="custom"
+                            customColor={RUN_STATUS_BADGE[run.status].color}
+                            customBgColor={RUN_STATUS_BADGE[run.status].bg}
+                          />
+                        </span>
+                        {/* Created */}
+                        <span className="text-text-muted">{fmtDate(run.createdAt)}</span>
+                      </TableRow>
                     );
                   }) as any)
                 )}

--- a/pages/deribit-agent/models.tsx
+++ b/pages/deribit-agent/models.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo } from 'react';
 import { AgentError } from '@/components/features/DeribitAgent/AgentError';
 import toast from 'react-hot-toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBrain, faPlus, faBan, faTrash, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faBrain, faPlus, faBan, faTrash, faPlay, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
@@ -36,15 +36,58 @@ const ALGORITHM_OPTIONS = [
   { value: 'A2C', label: 'A2C' },
 ];
 
-const STRATEGY_OPTIONS = [
-  { value: 'short_call', label: 'Short Call', desc: 'Sell calls at any delta (Δ20–Δ80)' },
-  { value: 'short_put', label: 'Short Put', desc: 'Sell puts at any delta (Δ10–Δ50)' },
+// Quick-selector chips — check/uncheck all actions in the group
+const STRATEGY_CHIPS = [
+  { value: 'short_call',    label: 'Short Call',    ids: [1,2,3,4,5,6,7] },
+  { value: 'short_put',     label: 'Short Put',     ids: [8,9,10,11,12] },
+  { value: 'delta_neutral', label: 'Delta Neutral', ids: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] },
+];
+
+// 27-action list grouped for display
+const ACTION_GROUPS = [
   {
-    value: 'delta_neutral',
-    label: 'Delta Neutral',
-    desc: 'Balanced call + put positioning, including one-action strangles',
+    label: 'Open Calls',
+    actions: [
+      { id: 1, label: 'ATM (Δ50)' }, { id: 2, label: 'OTM Δ40' }, { id: 3, label: 'OTM Δ30' },
+      { id: 4, label: 'OTM Δ20' },   { id: 5, label: 'ITM Δ60' }, { id: 6, label: 'ITM Δ70' },
+      { id: 7, label: 'ITM Δ80' },
+    ],
+  },
+  {
+    label: 'Open Puts',
+    actions: [
+      { id: 8, label: 'ATM (Δ50)' },     { id: 9, label: 'OTM Δ40' },
+      { id: 10, label: 'OTM Δ30' },      { id: 11, label: 'OTM Δ20' },
+      { id: 12, label: 'Far OTM Δ10' },
+    ],
+  },
+  {
+    label: 'Strangles',
+    actions: [
+      { id: 13, label: 'Δ40/Δ40' }, { id: 14, label: 'Δ30/Δ30' }, { id: 15, label: 'Δ20/Δ20' },
+    ],
+  },
+  {
+    label: 'Close All',
+    actions: [{ id: 16, label: 'Close all positions' }],
+  },
+  {
+    label: 'Close Call at Profit',
+    actions: [
+      { id: 17, label: '≥25%' }, { id: 18, label: '≥50%' }, { id: 19, label: '≥60%' },
+      { id: 20, label: '≥70%' }, { id: 21, label: '≥80%' },
+    ],
+  },
+  {
+    label: 'Close Put at Profit',
+    actions: [
+      { id: 22, label: '≥25%' }, { id: 23, label: '≥50%' }, { id: 24, label: '≥60%' },
+      { id: 25, label: '≥70%' }, { id: 26, label: '≥80%' },
+    ],
   },
 ];
+
+const ALL_ACTION_IDS = ACTION_GROUPS.flatMap(g => g.actions.map(a => a.id));
 
 const SESSION_STATUSES = ['QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'];
 const SESSION_HEADERS = ['Name', 'Currency', 'Algorithm', 'Status', 'Created'];
@@ -60,12 +103,7 @@ const MODEL_HEADERS = [
 ];
 const MODEL_STORAGE_TYPES = ['local', 's3'];
 
-const BLANK_SESSION: CreateSessionBody & {
-  allowedStrategies: string[];
-  riskProfile: Required<RiskProfile>;
-  totalTimesteps: number;
-  learningRate: number;
-} = {
+const BLANK_SESSION = {
   name: '',
   description: '',
   currency: 'BTC',
@@ -73,10 +111,23 @@ const BLANK_SESSION: CreateSessionBody & {
   dataTo: new Date().toISOString().slice(0, 10),
   resolution: '1D',
   algorithm: 'PPO',
-  allowedStrategies: ['short_call', 'short_put', 'delta_neutral'],
-  riskProfile: { maxDrawdown: 0.2, aggressionLevel: 0.5 },
+  allowedActions: [...ALL_ACTION_IDS] as number[],
+  expiryDaysMin: 7,
+  expiryDaysMax: 7,
+  rollDteThreshold: 0,
+  riskProfile: { maxDrawdown: 0.2, aggressionLevel: 0.5 } as Required<RiskProfile>,
   totalTimesteps: 100_000,
   learningRate: 0.005,
+  // Execution defaults (stored in hyperparams.env)
+  positionSizePct: 1.0,
+  maxPositionBtc: 5.0,
+  minOrderSize: 0.1,
+  maxMarginRatio: 0.8,
+  deltaThreshold: 0.30,
+  deltaPenaltyCoef: 0.002,
+  riskFreeRate: 0.05,
+  fastMargin: true,
+  showExecDefaults: false,
 };
 
 function aggressionLabel(level: number): string {
@@ -239,12 +290,22 @@ export default function ModelsPage() {
 
   const patchForm = (k: keyof typeof form, v: unknown) => setForm(f => ({ ...f, [k]: v }));
 
-  const toggleStrategy = (strategy: string) => {
+  const isChipActive = (ids: number[]) => ids.every(id => form.allowedActions.includes(id));
+
+  const toggleChip = (ids: number[]) => {
+    if (isChipActive(ids)) {
+      setForm(f => ({ ...f, allowedActions: f.allowedActions.filter(id => !ids.includes(id)) }));
+    } else {
+      setForm(f => ({ ...f, allowedActions: [...new Set([...f.allowedActions, ...ids])] }));
+    }
+  };
+
+  const toggleAction = (id: number) => {
     setForm(f => ({
       ...f,
-      allowedStrategies: f.allowedStrategies.includes(strategy)
-        ? f.allowedStrategies.filter(s => s !== strategy)
-        : [...f.allowedStrategies, strategy],
+      allowedActions: f.allowedActions.includes(id)
+        ? f.allowedActions.filter(x => x !== id)
+        : [...f.allowedActions, id],
     }));
   };
 
@@ -253,8 +314,8 @@ export default function ModelsPage() {
       toast.error('Name, currency, data from and data to are required.');
       return;
     }
-    if (!form.allowedStrategies.length) {
-      toast.error('Select at least one strategy to allow during training.');
+    if (!form.allowedActions.length) {
+      toast.error('Select at least one action to allow during training.');
       return;
     }
     setSubmitting(true);
@@ -262,19 +323,32 @@ export default function ModelsPage() {
       await agentFetch('/training/sessions', {
         method: 'POST',
         body: JSON.stringify({
-          name: form.name,
-          description: form.description || undefined,
-          currency: form.currency,
-          dataFrom: new Date(form.dataFrom).toISOString(),
-          dataTo: new Date(form.dataTo + 'T23:59:59').toISOString(),
-          resolution: form.resolution,
-          algorithm: form.algorithm,
-          allowedStrategies: form.allowedStrategies,
-          riskProfile: form.riskProfile,
+          name:             form.name,
+          description:      form.description || undefined,
+          currency:         form.currency,
+          dataFrom:         new Date(form.dataFrom).toISOString(),
+          dataTo:           new Date(form.dataTo + 'T23:59:59').toISOString(),
+          resolution:       form.resolution,
+          algorithm:        form.algorithm,
+          allowedActions:   form.allowedActions,
+          expiryDaysMin:    form.expiryDaysMin,
+          expiryDaysMax:    form.expiryDaysMax,
+          rollDteThreshold: form.rollDteThreshold,
+          riskProfile:      form.riskProfile,
           hyperparams: {
             training: {
               total_timesteps: form.totalTimesteps,
               learning_rate:   form.learningRate,
+            },
+            env: {
+              position_size_pct:  form.positionSizePct,
+              max_position_btc:   form.maxPositionBtc,
+              min_order_size:     form.minOrderSize,
+              max_margin_ratio:   form.maxMarginRatio,
+              delta_threshold:    form.deltaThreshold,
+              delta_penalty_coef: form.deltaPenaltyCoef,
+              risk_free_rate:     form.riskFreeRate,
+              fast_margin:        form.fastMargin,
             },
           },
         } satisfies CreateSessionBody),
@@ -430,44 +504,112 @@ export default function ModelsPage() {
               />
               <TextInput
                 label="Total Timesteps"
-                type="number"
                 value={String(form.totalTimesteps)}
                 onChange={v => patchForm('totalTimesteps', Math.max(1, parseInt(v) || 100_000))}
               />
               <TextInput
                 label="Learning Rate"
-                type="number"
                 value={String(form.learningRate)}
                 onChange={v => patchForm('learningRate', Math.max(0, parseFloat(v) || 0.005))}
               />
             </div>
 
+            {/* ── Allowed Actions ────────────────────────────────────────── */}
             <div className="mt-5">
-              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
-                Allowed Strategies
+              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+                Allowed Actions
               </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
-                {STRATEGY_OPTIONS.map(s => {
-                  const checked = form.allowedStrategies.includes(s.value);
+              {/* Quick-selector chips */}
+              <div className="flex gap-2 flex-wrap mb-3">
+                {STRATEGY_CHIPS.map(chip => {
+                  const active = isChipActive(chip.ids);
                   return (
                     <button
-                      key={s.value}
+                      key={chip.value}
                       type="button"
-                      onClick={() => toggleStrategy(s.value)}
-                      className={`text-left px-3 py-2.5 rounded-lg border-2 transition-colors ${
-                        checked
-                          ? 'border-brand bg-brand/5 text-brand'
-                          : 'border-input-border text-text-secondary hover:border-brand/50'
+                      onClick={() => toggleChip(chip.ids)}
+                      className={`px-3 py-1.5 rounded-full border text-xs font-medium transition-colors ${
+                        active
+                          ? 'border-brand bg-brand/10 text-brand'
+                          : 'border-input-border text-text-secondary hover:border-brand/40'
                       }`}
                     >
-                      <div className="text-sm font-medium">{s.label}</div>
-                      <div className="text-xs text-text-muted mt-0.5">{s.desc}</div>
+                      {chip.label}
                     </button>
                   );
                 })}
+                <button
+                  type="button"
+                  onClick={() => setForm(f => ({ ...f, allowedActions: [...ALL_ACTION_IDS] }))}
+                  className="px-3 py-1.5 rounded-full border border-input-border text-xs text-text-muted hover:text-text-primary transition-colors"
+                >
+                  All
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setForm(f => ({ ...f, allowedActions: [] }))}
+                  className="px-3 py-1.5 rounded-full border border-input-border text-xs text-text-muted hover:text-text-primary transition-colors"
+                >
+                  None
+                </button>
+              </div>
+              {/* Per-action checkboxes grouped */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-3">
+                {ACTION_GROUPS.map(group => (
+                  <div key={group.label}>
+                    <p className="text-xs text-text-muted font-medium mb-1">{group.label}</p>
+                    <div className="space-y-1">
+                      {group.actions.map(a => (
+                        <label key={a.id} className="flex items-center gap-2 cursor-pointer group">
+                          <input
+                            type="checkbox"
+                            checked={form.allowedActions.includes(a.id)}
+                            onChange={() => toggleAction(a.id)}
+                            className="w-3.5 h-3.5 accent-brand"
+                          />
+                          <span className="text-xs text-text-secondary group-hover:text-text-primary transition-colors">
+                            {a.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
 
+            {/* ── DTE Range ─────────────────────────────────────────────── */}
+            <div className="mt-5">
+              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                Expiry (DTE)
+              </p>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <TextInput
+                  label="Min DTE"
+                  value={String(form.expiryDaysMin)}
+                  onChange={v => patchForm('expiryDaysMin', Math.max(1, parseInt(v) || 7))}
+                />
+                <TextInput
+                  label="Max DTE"
+                  value={String(form.expiryDaysMax)}
+                  onChange={v => patchForm('expiryDaysMax', Math.max(form.expiryDaysMin, parseInt(v) || 7))}
+                />
+                <SliderInput
+                  label="Roll threshold (DTE)"
+                  value={form.rollDteThreshold}
+                  onChange={v => patchForm('rollDteThreshold', v)}
+                  min={0}
+                  max={7}
+                  step={1}
+                  formatValue={v => v === 0 ? 'Hold to expiry' : `Roll at ≤${v}d`}
+                  minLabel="Hold"
+                  maxLabel="Roll early"
+                  hint="Close positions early when DTE reaches this threshold."
+                />
+              </div>
+            </div>
+
+            {/* ── Risk Profile ──────────────────────────────────────────── */}
             <div className="mt-5">
               <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
                 Risk Profile
@@ -476,38 +618,105 @@ export default function ModelsPage() {
                 <SliderInput
                   label="Max Drawdown"
                   value={form.riskProfile.maxDrawdown * 100}
-                  onChange={v =>
-                    setForm(f => ({
-                      ...f,
-                      riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 },
-                    }))
-                  }
-                  min={5}
-                  max={50}
-                  step={5}
+                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 } }))}
+                  min={5} max={50} step={5}
                   formatValue={v => `${v.toFixed(0)}%`}
-                  minLabel="5% (tight)"
-                  maxLabel="50% (loose)"
+                  minLabel="5% (tight)" maxLabel="50% (loose)"
                   hint="Episode ends early when cumulative loss exceeds this threshold."
                 />
                 <SliderInput
                   label="Aggression Level"
                   value={form.riskProfile.aggressionLevel * 100}
-                  onChange={v =>
-                    setForm(f => ({
-                      ...f,
-                      riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 },
-                    }))
-                  }
-                  min={0}
-                  max={100}
-                  step={10}
+                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 } }))}
+                  min={0} max={100} step={10}
                   formatValue={v => aggressionLabel(v / 100)}
-                  minLabel="Passive"
-                  maxLabel="Aggressive"
+                  minLabel="Passive" maxLabel="Aggressive"
                   hint="Scales position size, exploration rate, and loss penalty."
                 />
               </div>
+            </div>
+
+            {/* ── Execution Defaults (collapsible) ──────────────────────── */}
+            <div className="mt-5 border-t border-surface pt-4">
+              <button
+                type="button"
+                className="flex items-center gap-2 text-xs font-semibold text-text-muted uppercase tracking-wider hover:text-text-primary transition-colors"
+                onClick={() => patchForm('showExecDefaults', !form.showExecDefaults)}
+              >
+                <FontAwesomeIcon icon={form.showExecDefaults ? faChevronUp : faChevronDown} className="w-3 h-3" />
+                Execution Defaults
+              </button>
+              {form.showExecDefaults && (
+                <div className="mt-4 space-y-5">
+                  <div>
+                    <p className="text-xs text-text-muted mb-3">Position Sizing</p>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                      <SliderInput
+                        label="Position Size %"
+                        value={form.positionSizePct * 100}
+                        onChange={v => patchForm('positionSizePct', v / 100)}
+                        min={5} max={100} step={5}
+                        formatValue={v => `${v.toFixed(0)}%`}
+                        minLabel="5%" maxLabel="100%"
+                        hint="Fraction of margin allocated per leg."
+                      />
+                      <TextInput
+                        label="Max Position BTC"
+                        value={String(form.maxPositionBtc)}
+                        onChange={v => patchForm('maxPositionBtc', parseFloat(v) || 5)}
+                      />
+                      <TextInput
+                        label="Min Order Size BTC"
+                        value={String(form.minOrderSize)}
+                        onChange={v => patchForm('minOrderSize', parseFloat(v) || 0.1)}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <SliderInput
+                      label="Max Margin Ratio"
+                      value={form.maxMarginRatio * 100}
+                      onChange={v => patchForm('maxMarginRatio', v / 100)}
+                      min={50} max={95} step={5}
+                      formatValue={v => `${v.toFixed(0)}%`}
+                      minLabel="50%" maxLabel="95%"
+                      hint="Max portfolio margin utilization before blocking new trades."
+                    />
+                    <SliderInput
+                      label="Delta Threshold"
+                      value={form.deltaThreshold * 100}
+                      onChange={v => patchForm('deltaThreshold', v / 100)}
+                      min={10} max={80} step={5}
+                      formatValue={v => `${v.toFixed(0)}%`}
+                      minLabel="10% (strict)" maxLabel="80% (loose)"
+                      hint="Net delta overshoot allowed before penalty kicks in."
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <TextInput
+                      label="Delta Penalty Coef"
+                      value={String(form.deltaPenaltyCoef)}
+                      onChange={v => patchForm('deltaPenaltyCoef', parseFloat(v) || 0.002)}
+                    />
+                    <TextInput
+                      label="Risk Free Rate"
+                      value={String(form.riskFreeRate)}
+                      onChange={v => patchForm('riskFreeRate', parseFloat(v) || 0.05)}
+                    />
+                    <div>
+                      <p className="text-xs text-text-muted mb-2">Fast Margin</p>
+                      <button
+                        type="button"
+                        onClick={() => patchForm('fastMargin', !form.fastMargin)}
+                        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${form.fastMargin ? 'bg-brand' : 'bg-input-border'}`}
+                      >
+                        <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${form.fastMargin ? 'translate-x-6' : 'translate-x-1'}`} />
+                      </button>
+                      <p className="text-xs text-text-muted mt-1">Skip IV shocks — faster, less precise.</p>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="flex gap-3 mt-5">

--- a/pages/deribit-agent/models.tsx
+++ b/pages/deribit-agent/models.tsx
@@ -3,7 +3,15 @@ import { useState, useMemo } from 'react';
 import { AgentError } from '@/components/features/DeribitAgent/AgentError';
 import toast from 'react-hot-toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBrain, faPlus, faBan, faTrash, faPlay, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBrain,
+  faPlus,
+  faBan,
+  faTrash,
+  faPlay,
+  faChevronDown,
+  faChevronUp,
+} from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
@@ -38,9 +46,13 @@ const ALGORITHM_OPTIONS = [
 
 // Quick-selector chips — check/uncheck all actions in the group
 const STRATEGY_CHIPS = [
-  { value: 'short_call',    label: 'Short Call',    ids: [1,2,3,4,5,6,7] },
-  { value: 'short_put',     label: 'Short Put',     ids: [8,9,10,11,12] },
-  { value: 'delta_neutral', label: 'Delta Neutral', ids: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15] },
+  { value: 'short_call', label: 'Short Call', ids: [1, 2, 3, 4, 5, 6, 7] },
+  { value: 'short_put', label: 'Short Put', ids: [8, 9, 10, 11, 12] },
+  {
+    value: 'delta_neutral',
+    label: 'Delta Neutral',
+    ids: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+  },
 ];
 
 // 27-action list grouped for display
@@ -48,23 +60,31 @@ const ACTION_GROUPS = [
   {
     label: 'Open Calls',
     actions: [
-      { id: 1, label: 'ATM (Δ50)' }, { id: 2, label: 'OTM Δ40' }, { id: 3, label: 'OTM Δ30' },
-      { id: 4, label: 'OTM Δ20' },   { id: 5, label: 'ITM Δ60' }, { id: 6, label: 'ITM Δ70' },
+      { id: 1, label: 'ATM (Δ50)' },
+      { id: 2, label: 'OTM Δ40' },
+      { id: 3, label: 'OTM Δ30' },
+      { id: 4, label: 'OTM Δ20' },
+      { id: 5, label: 'ITM Δ60' },
+      { id: 6, label: 'ITM Δ70' },
       { id: 7, label: 'ITM Δ80' },
     ],
   },
   {
     label: 'Open Puts',
     actions: [
-      { id: 8, label: 'ATM (Δ50)' },     { id: 9, label: 'OTM Δ40' },
-      { id: 10, label: 'OTM Δ30' },      { id: 11, label: 'OTM Δ20' },
+      { id: 8, label: 'ATM (Δ50)' },
+      { id: 9, label: 'OTM Δ40' },
+      { id: 10, label: 'OTM Δ30' },
+      { id: 11, label: 'OTM Δ20' },
       { id: 12, label: 'Far OTM Δ10' },
     ],
   },
   {
     label: 'Strangles',
     actions: [
-      { id: 13, label: 'Δ40/Δ40' }, { id: 14, label: 'Δ30/Δ30' }, { id: 15, label: 'Δ20/Δ20' },
+      { id: 13, label: 'Δ40/Δ40' },
+      { id: 14, label: 'Δ30/Δ30' },
+      { id: 15, label: 'Δ20/Δ20' },
     ],
   },
   {
@@ -74,15 +94,21 @@ const ACTION_GROUPS = [
   {
     label: 'Close Call at Profit',
     actions: [
-      { id: 17, label: '≥25%' }, { id: 18, label: '≥50%' }, { id: 19, label: '≥60%' },
-      { id: 20, label: '≥70%' }, { id: 21, label: '≥80%' },
+      { id: 17, label: '≥25%' },
+      { id: 18, label: '≥50%' },
+      { id: 19, label: '≥60%' },
+      { id: 20, label: '≥70%' },
+      { id: 21, label: '≥80%' },
     ],
   },
   {
     label: 'Close Put at Profit',
     actions: [
-      { id: 22, label: '≥25%' }, { id: 23, label: '≥50%' }, { id: 24, label: '≥60%' },
-      { id: 25, label: '≥70%' }, { id: 26, label: '≥80%' },
+      { id: 22, label: '≥25%' },
+      { id: 23, label: '≥50%' },
+      { id: 24, label: '≥60%' },
+      { id: 25, label: '≥70%' },
+      { id: 26, label: '≥80%' },
     ],
   },
 ];
@@ -119,15 +145,17 @@ const BLANK_SESSION = {
   totalTimesteps: 100_000,
   learningRate: 0.005,
   // Execution defaults (stored in hyperparams.env)
-  positionSizePct: 1.0,
+  positionSizePct: 0.8,
   maxPositionBtc: 5.0,
   minOrderSize: 0.1,
   maxMarginRatio: 0.8,
-  deltaThreshold: 0.30,
+  deltaThreshold: 0.3,
   deltaPenaltyCoef: 0.002,
   riskFreeRate: 0.05,
   fastMargin: true,
   showExecDefaults: false,
+  // Continue-training fields
+  resumeFromModelId: '',
 };
 
 function aggressionLabel(level: number): string {
@@ -147,7 +175,7 @@ function resolveModelName(m: TrainedModel): string {
 function fmtSteps(n?: number | null): string {
   if (!n) return '—';
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000)     return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
   return String(n);
 }
 
@@ -159,6 +187,7 @@ function fmtSize(bytes?: number): string {
 
 export default function ModelsPage() {
   const [showCreate, setShowCreate] = useState(false);
+  const [createMode, setCreateMode] = useState<'new' | 'continue'>('new');
   const [form, setForm] = useState(BLANK_SESSION);
   const [submitting, setSubmitting] = useState(false);
   const [cancelling, setCancelling] = useState<string | null>(null);
@@ -310,8 +339,16 @@ export default function ModelsPage() {
   };
 
   const createSession = async () => {
-    if (!form.name || !form.currency || !form.dataFrom || !form.dataTo) {
-      toast.error('Name, currency, data from and data to are required.');
+    if (!form.name || !form.dataFrom || !form.dataTo) {
+      toast.error('Name, data from and data to are required.');
+      return;
+    }
+    if (createMode === 'new' && !form.currency) {
+      toast.error('Currency is required.');
+      return;
+    }
+    if (createMode === 'continue' && !form.resumeFromModelId) {
+      toast.error('Select a base model to continue training from.');
       return;
     }
     if (!form.allowedActions.length) {
@@ -323,38 +360,39 @@ export default function ModelsPage() {
       await agentFetch('/training/sessions', {
         method: 'POST',
         body: JSON.stringify({
-          name:             form.name,
-          description:      form.description || undefined,
-          currency:         form.currency,
-          dataFrom:         new Date(form.dataFrom).toISOString(),
-          dataTo:           new Date(form.dataTo + 'T23:59:59').toISOString(),
-          resolution:       form.resolution,
-          algorithm:        form.algorithm,
-          allowedActions:   form.allowedActions,
-          expiryDaysMin:    form.expiryDaysMin,
-          expiryDaysMax:    form.expiryDaysMax,
+          name: form.name,
+          description: form.description || undefined,
+          ...(createMode === 'new' && { currency: form.currency, algorithm: form.algorithm }),
+          ...(createMode === 'continue' && { resumeFromModelId: form.resumeFromModelId }),
+          dataFrom: new Date(form.dataFrom).toISOString(),
+          dataTo: new Date(form.dataTo + 'T23:59:59').toISOString(),
+          resolution: form.resolution,
+          allowedActions: form.allowedActions,
+          expiryDaysMin: form.expiryDaysMin,
+          expiryDaysMax: form.expiryDaysMax,
           rollDteThreshold: form.rollDteThreshold,
-          riskProfile:      form.riskProfile,
+          riskProfile: form.riskProfile,
           hyperparams: {
             training: {
               total_timesteps: form.totalTimesteps,
-              learning_rate:   form.learningRate,
+              learning_rate: form.learningRate,
             },
             env: {
-              position_size_pct:  form.positionSizePct,
-              max_position_btc:   form.maxPositionBtc,
-              min_order_size:     form.minOrderSize,
-              max_margin_ratio:   form.maxMarginRatio,
-              delta_threshold:    form.deltaThreshold,
+              position_size_pct: form.positionSizePct,
+              max_position_btc: form.maxPositionBtc,
+              min_order_size: form.minOrderSize,
+              max_margin_ratio: form.maxMarginRatio,
+              delta_threshold: form.deltaThreshold,
               delta_penalty_coef: form.deltaPenaltyCoef,
-              risk_free_rate:     form.riskFreeRate,
-              fast_margin:        form.fastMargin,
+              risk_free_rate: form.riskFreeRate,
+              fast_margin: form.fastMargin,
             },
           },
         } satisfies CreateSessionBody),
       });
       toast.success('Training session queued.');
       setForm(BLANK_SESSION);
+      setCreateMode('new');
       setShowCreate(false);
       sessions.refetch();
     } catch (e) {
@@ -451,7 +489,11 @@ export default function ModelsPage() {
           actions={
             <button
               type="button"
-              onClick={() => setShowCreate(v => !v)}
+              onClick={() => {
+                setShowCreate(v => !v);
+                setCreateMode('new');
+                setForm(BLANK_SESSION);
+              }}
               className="inline-flex items-center gap-2 bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 transition-colors"
             >
               <FontAwesomeIcon icon={faPlus} className="w-3 h-3" />
@@ -463,12 +505,79 @@ export default function ModelsPage() {
         {/* ── Create form ────────────────────────────────────────────────────── */}
         {showCreate && (
           <Card className="mt-4">
-            <p className="text-sm font-semibold text-text-primary mb-4">Create Training Model</p>
+            <p className="text-sm font-semibold text-text-primary mb-4">Create Training Session</p>
+
+            {/* Mode toggle */}
+            <div className="flex gap-1 p-1 bg-surface rounded-lg w-fit mb-5">
+              <button
+                type="button"
+                onClick={() => setCreateMode('new')}
+                className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  createMode === 'new'
+                    ? 'bg-card text-text-primary shadow-sm'
+                    : 'text-text-muted hover:text-text-secondary'
+                }`}
+              >
+                New Model
+              </button>
+              <button
+                type="button"
+                onClick={() => setCreateMode('continue')}
+                className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                  createMode === 'continue'
+                    ? 'bg-card text-text-primary shadow-sm'
+                    : 'text-text-muted hover:text-text-secondary'
+                }`}
+              >
+                Continue Training
+              </button>
+            </div>
+
+            {/* Base model selector (continue mode only) */}
+            {createMode === 'continue' &&
+              (() => {
+                const completedModels = (models.data ?? []).filter(
+                  m => !m.session?.status || m.session.status === 'COMPLETED'
+                );
+                const selectedBase = completedModels.find(m => m.id === form.resumeFromModelId);
+                return (
+                  <>
+                    <SelectInput
+                      label="Base Model"
+                      options={[
+                        { value: '', label: 'Select a model to continue from…' },
+                        ...completedModels.map(m => ({
+                          value: m.id,
+                          label: `${resolveModelName(m)} · ${m.session?.currency ?? '?'} · ${m.session?.algorithm ?? 'PPO'}`,
+                        })),
+                      ]}
+                      value={form.resumeFromModelId}
+                      onChange={v => patchForm('resumeFromModelId', v)}
+                    />
+                    {selectedBase && (
+                      <div className="flex items-center gap-2 mt-2">
+                        <span className="text-xs text-text-muted">Inherits:</span>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono bg-surface border border-input-border text-text-secondary">
+                          {selectedBase.session?.currency ?? '?'}
+                        </span>
+                        <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono bg-surface border border-input-border text-text-secondary">
+                          {selectedBase.session?.algorithm ?? 'PPO'}
+                        </span>
+                        {selectedBase.metadata?.obs_version && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono bg-surface border border-input-border text-text-muted">
+                            obs {selectedBase.metadata.obs_version}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <TextInput
                 label="Name"
-                placeholder="btc-ppo-v1"
+                placeholder="btc-ppo-v2"
                 value={form.name}
                 onChange={v => patchForm('name', v)}
               />
@@ -478,18 +587,22 @@ export default function ModelsPage() {
                 value={form.description ?? ''}
                 onChange={v => patchForm('description', v)}
               />
-              <SelectInput
-                label="Currency"
-                options={CURRENCY_OPTIONS}
-                value={form.currency}
-                onChange={v => patchForm('currency', v)}
-              />
-              <SelectInput
-                label="Algorithm"
-                options={ALGORITHM_OPTIONS}
-                value={form.algorithm ?? 'PPO'}
-                onChange={v => patchForm('algorithm', v)}
-              />
+              {createMode === 'new' && (
+                <>
+                  <SelectInput
+                    label="Currency"
+                    options={CURRENCY_OPTIONS}
+                    value={form.currency}
+                    onChange={v => patchForm('currency', v)}
+                  />
+                  <SelectInput
+                    label="Algorithm"
+                    options={ALGORITHM_OPTIONS}
+                    value={form.algorithm ?? 'PPO'}
+                    onChange={v => patchForm('algorithm', v)}
+                  />
+                </>
+              )}
               <TextInput
                 label="Data From"
                 type="date"
@@ -592,7 +705,9 @@ export default function ModelsPage() {
                 <TextInput
                   label="Max DTE"
                   value={String(form.expiryDaysMax)}
-                  onChange={v => patchForm('expiryDaysMax', Math.max(form.expiryDaysMin, parseInt(v) || 7))}
+                  onChange={v =>
+                    patchForm('expiryDaysMax', Math.max(form.expiryDaysMin, parseInt(v) || 7))
+                  }
                 />
                 <SliderInput
                   label="Roll threshold (DTE)"
@@ -601,7 +716,7 @@ export default function ModelsPage() {
                   min={0}
                   max={7}
                   step={1}
-                  formatValue={v => v === 0 ? 'Hold to expiry' : `Roll at ≤${v}d`}
+                  formatValue={v => (v === 0 ? 'Hold to expiry' : `Roll at ≤${v}d`)}
                   minLabel="Hold"
                   maxLabel="Roll early"
                   hint="Close positions early when DTE reaches this threshold."
@@ -618,19 +733,35 @@ export default function ModelsPage() {
                 <SliderInput
                   label="Max Drawdown"
                   value={form.riskProfile.maxDrawdown * 100}
-                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 } }))}
-                  min={5} max={50} step={5}
+                  onChange={v =>
+                    setForm(f => ({
+                      ...f,
+                      riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 },
+                    }))
+                  }
+                  min={5}
+                  max={50}
+                  step={5}
                   formatValue={v => `${v.toFixed(0)}%`}
-                  minLabel="5% (tight)" maxLabel="50% (loose)"
+                  minLabel="5% (tight)"
+                  maxLabel="50% (loose)"
                   hint="Episode ends early when cumulative loss exceeds this threshold."
                 />
                 <SliderInput
                   label="Aggression Level"
                   value={form.riskProfile.aggressionLevel * 100}
-                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 } }))}
-                  min={0} max={100} step={10}
+                  onChange={v =>
+                    setForm(f => ({
+                      ...f,
+                      riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 },
+                    }))
+                  }
+                  min={0}
+                  max={100}
+                  step={10}
                   formatValue={v => aggressionLabel(v / 100)}
-                  minLabel="Passive" maxLabel="Aggressive"
+                  minLabel="Passive"
+                  maxLabel="Aggressive"
                   hint="Scales position size, exploration rate, and loss penalty."
                 />
               </div>
@@ -643,7 +774,10 @@ export default function ModelsPage() {
                 className="flex items-center gap-2 text-xs font-semibold text-text-muted uppercase tracking-wider hover:text-text-primary transition-colors"
                 onClick={() => patchForm('showExecDefaults', !form.showExecDefaults)}
               >
-                <FontAwesomeIcon icon={form.showExecDefaults ? faChevronUp : faChevronDown} className="w-3 h-3" />
+                <FontAwesomeIcon
+                  icon={form.showExecDefaults ? faChevronUp : faChevronDown}
+                  className="w-3 h-3"
+                />
                 Execution Defaults
               </button>
               {form.showExecDefaults && (
@@ -655,9 +789,12 @@ export default function ModelsPage() {
                         label="Position Size %"
                         value={form.positionSizePct * 100}
                         onChange={v => patchForm('positionSizePct', v / 100)}
-                        min={5} max={100} step={5}
+                        min={5}
+                        max={100}
+                        step={5}
                         formatValue={v => `${v.toFixed(0)}%`}
-                        minLabel="5%" maxLabel="100%"
+                        minLabel="5%"
+                        maxLabel="100%"
                         hint="Fraction of margin allocated per leg."
                       />
                       <TextInput
@@ -677,18 +814,24 @@ export default function ModelsPage() {
                       label="Max Margin Ratio"
                       value={form.maxMarginRatio * 100}
                       onChange={v => patchForm('maxMarginRatio', v / 100)}
-                      min={50} max={95} step={5}
+                      min={50}
+                      max={95}
+                      step={5}
                       formatValue={v => `${v.toFixed(0)}%`}
-                      minLabel="50%" maxLabel="95%"
+                      minLabel="50%"
+                      maxLabel="95%"
                       hint="Max portfolio margin utilization before blocking new trades."
                     />
                     <SliderInput
                       label="Delta Threshold"
                       value={form.deltaThreshold * 100}
                       onChange={v => patchForm('deltaThreshold', v / 100)}
-                      min={10} max={80} step={5}
+                      min={10}
+                      max={80}
+                      step={5}
                       formatValue={v => `${v.toFixed(0)}%`}
-                      minLabel="10% (strict)" maxLabel="80% (loose)"
+                      minLabel="10% (strict)"
+                      maxLabel="80% (loose)"
                       hint="Net delta overshoot allowed before penalty kicks in."
                     />
                   </div>
@@ -710,9 +853,13 @@ export default function ModelsPage() {
                         onClick={() => patchForm('fastMargin', !form.fastMargin)}
                         className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${form.fastMargin ? 'bg-brand' : 'bg-input-border'}`}
                       >
-                        <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${form.fastMargin ? 'translate-x-6' : 'translate-x-1'}`} />
+                        <span
+                          className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${form.fastMargin ? 'translate-x-6' : 'translate-x-1'}`}
+                        />
                       </button>
-                      <p className="text-xs text-text-muted mt-1">Skip IV shocks — faster, less precise.</p>
+                      <p className="text-xs text-text-muted mt-1">
+                        Skip IV shocks — faster, less precise.
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -730,7 +877,11 @@ export default function ModelsPage() {
               </button>
               <button
                 type="button"
-                onClick={() => setShowCreate(false)}
+                onClick={() => {
+                  setShowCreate(false);
+                  setCreateMode('new');
+                  setForm(BLANK_SESSION);
+                }}
                 className="px-4 py-2 rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors"
               >
                 Cancel

--- a/pages/deribit-agent/models.tsx
+++ b/pages/deribit-agent/models.tsx
@@ -3,7 +3,7 @@ import { useState, useMemo } from 'react';
 import { AgentError } from '@/components/features/DeribitAgent/AgentError';
 import toast from 'react-hot-toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBrain, faPlus, faBan, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faBrain, faPlus, faBan, faTrash, faPlay } from '@fortawesome/free-solid-svg-icons';
 import { Section, PageHeader } from '@/components/ui/Layout';
 import Card from '@/components/ui/Card';
 import { Badge } from '@/components/ui/Badge';
@@ -14,9 +14,14 @@ import TableHeadSearchable from '@/components/ui/Table/TableHeadSearchable';
 import TableBody from '@/components/ui/Table/TableBody';
 import TableRow from '@/components/ui/Table/TableRow';
 import TableRowEmpty from '@/components/ui/Table/TableRowEmpty';
+import { CellEditable } from '@/components/ui/CellEditable';
 import {
-  useDeribitFetch, agentFetch,
-  type TrainingSession, type TrainedModel, type CreateSessionBody, type RiskProfile,
+  useDeribitFetch,
+  agentFetch,
+  type TrainingSession,
+  type TrainedModel,
+  type CreateSessionBody,
+  type RiskProfile,
 } from '@/lib/deribit-agent/client';
 import { SESSION_STATUS_BADGE, fmt, fmtDate } from '@/lib/deribit-agent/ui';
 
@@ -32,20 +37,36 @@ const ALGORITHM_OPTIONS = [
 ];
 
 const STRATEGY_OPTIONS = [
-  { value: 'STRANGLE',        label: 'Strangle',         desc: 'Sell OTM call + put simultaneously' },
-  { value: 'STRADDLE',        label: 'Straddle',         desc: 'Sell ATM call + put' },
-  { value: 'DELTA_NEUTRAL',   label: 'Delta Neutral',    desc: 'Hedge to near-zero net delta' },
-  { value: 'COVERED_CALL',    label: 'Covered Call',     desc: 'Sell calls against a long position' },
-  { value: 'CASH_SECURED_PUT',label: 'Cash-Secured Put', desc: 'Sell puts with full margin reserved' },
-  { value: 'IRON_CONDOR',     label: 'Iron Condor',      desc: 'Sell OTM strangle, buy further OTM wings' },
+  { value: 'STRANGLE', label: 'Strangle', desc: 'Sell OTM call + put simultaneously' },
+  { value: 'STRADDLE', label: 'Straddle', desc: 'Sell ATM call + put' },
+  { value: 'DELTA_NEUTRAL', label: 'Delta Neutral', desc: 'Hedge to near-zero net delta' },
+  { value: 'COVERED_CALL', label: 'Covered Call', desc: 'Sell calls against a long position' },
+  {
+    value: 'CASH_SECURED_PUT',
+    label: 'Cash-Secured Put',
+    desc: 'Sell puts with full margin reserved',
+  },
+  { value: 'IRON_CONDOR', label: 'Iron Condor', desc: 'Sell OTM strangle, buy further OTM wings' },
 ];
 
-const SESSION_STATUSES   = ['QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'];
-const SESSION_HEADERS    = ['Name', 'Currency', 'Algorithm', 'Status', 'Created'];
-const MODEL_HEADERS      = ['Name', 'Algorithm', 'Sharpe', 'Max DD', 'Win Rate', 'Mean Reward', 'Size', 'Created'];
+const SESSION_STATUSES = ['QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'];
+const SESSION_HEADERS = ['Name', 'Currency', 'Algorithm', 'Status', 'Created'];
+const MODEL_HEADERS = [
+  'Name',
+  'Algorithm',
+  'Sharpe',
+  'Max DD',
+  'Win Rate',
+  'Mean Reward',
+  'Size',
+  'Created',
+];
 const MODEL_STORAGE_TYPES = ['local', 's3'];
 
-const BLANK_SESSION: CreateSessionBody & { allowedStrategies: string[]; riskProfile: Required<RiskProfile> } = {
+const BLANK_SESSION: CreateSessionBody & {
+  allowedStrategies: string[];
+  riskProfile: Required<RiskProfile>;
+} = {
   name: '',
   description: '',
   currency: 'BTC',
@@ -54,7 +75,7 @@ const BLANK_SESSION: CreateSessionBody & { allowedStrategies: string[]; riskProf
   resolution: '1D',
   algorithm: 'PPO',
   allowedStrategies: ['STRANGLE', 'DELTA_NEUTRAL'],
-  riskProfile: { maxDrawdown: 0.20, aggressionLevel: 0.5 },
+  riskProfile: { maxDrawdown: 0.2, aggressionLevel: 0.5 },
 };
 
 function aggressionLabel(level: number): string {
@@ -63,6 +84,12 @@ function aggressionLabel(level: number): string {
   if (level <= 0.6) return 'Balanced';
   if (level <= 0.8) return 'Aggressive';
   return 'Very Aggressive';
+}
+
+// If model.name is still the trainer's auto-generated filename (e.g. cmowte83_ppo),
+// show the session name as the human-readable fallback.
+function resolveModelName(m: TrainedModel): string {
+  return /_(ppo|dqn|a2c)$/i.test(m.name) ? (m.session?.name ?? m.name) : m.name;
 }
 
 function fmtSize(bytes?: number): string {
@@ -77,6 +104,7 @@ export default function ModelsPage() {
   const [submitting, setSubmitting] = useState(false);
   const [cancelling, setCancelling] = useState<string | null>(null);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [pushingBacktest, setPushingBacktest] = useState<string | null>(null);
 
   // Session table controls
   const [sessionSearch, setSessionSearch] = useState('');
@@ -91,7 +119,7 @@ export default function ModelsPage() {
   const [modelSortReverse, setModelSortReverse] = useState(true);
 
   const sessions = useDeribitFetch<TrainingSession[]>('/training/sessions');
-  const models   = useDeribitFetch<TrainedModel[]>('/training/models');
+  const models = useDeribitFetch<TrainedModel[]>('/training/models');
 
   // ── Session filtering / sorting ─────────────────────────────────────────────
 
@@ -99,10 +127,11 @@ export default function ModelsPage() {
     let data = sessions.data ?? [];
     if (sessionSearch) {
       const q = sessionSearch.toLowerCase();
-      data = data.filter(s =>
-        s.name.toLowerCase().includes(q) ||
-        s.description?.toLowerCase().includes(q) ||
-        s.algorithm.toLowerCase().includes(q)
+      data = data.filter(
+        s =>
+          s.name.toLowerCase().includes(q) ||
+          s.description?.toLowerCase().includes(q) ||
+          s.algorithm.toLowerCase().includes(q)
       );
     }
     if (activeStatuses.length) {
@@ -111,11 +140,24 @@ export default function ModelsPage() {
     return [...data].sort((a, b) => {
       let cmp = 0;
       switch (sessionSortCol) {
-        case 'Name':      cmp = a.name.localeCompare(b.name); break;
-        case 'Currency':  cmp = a.currency.localeCompare(b.currency); break;
-        case 'Algorithm': cmp = a.algorithm.localeCompare(b.algorithm); break;
-        case 'Status':    cmp = a.status.localeCompare(b.status); break;
-        case 'Created':   cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(); break;
+        case 'Name':
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case 'Model Name':
+          cmp = (a.model?.name ?? '').localeCompare(b.model?.name ?? '');
+          break;
+        case 'Currency':
+          cmp = a.currency.localeCompare(b.currency);
+          break;
+        case 'Algorithm':
+          cmp = a.algorithm.localeCompare(b.algorithm);
+          break;
+        case 'Status':
+          cmp = a.status.localeCompare(b.status);
+          break;
+        case 'Created':
+          cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
       }
       return sessionSortReverse ? -cmp : cmp;
     });
@@ -123,7 +165,10 @@ export default function ModelsPage() {
 
   const handleSessionSort = (col: string) => {
     if (sessionSortCol === col) setSessionSortReverse(r => !r);
-    else { setSessionSortCol(col); setSessionSortReverse(false); }
+    else {
+      setSessionSortCol(col);
+      setSessionSortReverse(false);
+    }
   };
 
   // ── Model filtering / sorting ────────────────────────────────────────────────
@@ -132,10 +177,11 @@ export default function ModelsPage() {
     let data = models.data ?? [];
     if (modelSearch) {
       const q = modelSearch.toLowerCase();
-      data = data.filter(m =>
-        m.name.toLowerCase().includes(q) ||
-        m.session?.name.toLowerCase().includes(q) ||
-        m.session?.algorithm.toLowerCase().includes(q)
+      data = data.filter(
+        m =>
+          m.name.toLowerCase().includes(q) ||
+          m.session?.name.toLowerCase().includes(q) ||
+          m.session?.algorithm.toLowerCase().includes(q)
       );
     }
     if (activeStorageTypes.length) {
@@ -144,14 +190,30 @@ export default function ModelsPage() {
     return [...data].sort((a, b) => {
       let cmp = 0;
       switch (modelSortCol) {
-        case 'Name':        cmp = a.name.localeCompare(b.name); break;
-        case 'Algorithm':   cmp = (a.session?.algorithm ?? '').localeCompare(b.session?.algorithm ?? ''); break;
-        case 'Sharpe':      cmp = (a.sharpeRatio ?? -Infinity) - (b.sharpeRatio ?? -Infinity); break;
-        case 'Max DD':      cmp = (a.maxDrawdown ?? -Infinity) - (b.maxDrawdown ?? -Infinity); break;
-        case 'Win Rate':    cmp = (a.winRate ?? -Infinity) - (b.winRate ?? -Infinity); break;
-        case 'Mean Reward': cmp = (a.meanReward ?? -Infinity) - (b.meanReward ?? -Infinity); break;
-        case 'Size':        cmp = (a.sizeBytes ?? 0) - (b.sizeBytes ?? 0); break;
-        case 'Created':     cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(); break;
+        case 'Name':
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case 'Algorithm':
+          cmp = (a.session?.algorithm ?? '').localeCompare(b.session?.algorithm ?? '');
+          break;
+        case 'Sharpe':
+          cmp = (a.sharpeRatio ?? -Infinity) - (b.sharpeRatio ?? -Infinity);
+          break;
+        case 'Max DD':
+          cmp = (a.maxDrawdown ?? -Infinity) - (b.maxDrawdown ?? -Infinity);
+          break;
+        case 'Win Rate':
+          cmp = (a.winRate ?? -Infinity) - (b.winRate ?? -Infinity);
+          break;
+        case 'Mean Reward':
+          cmp = (a.meanReward ?? -Infinity) - (b.meanReward ?? -Infinity);
+          break;
+        case 'Size':
+          cmp = (a.sizeBytes ?? 0) - (b.sizeBytes ?? 0);
+          break;
+        case 'Created':
+          cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
       }
       return modelSortReverse ? -cmp : cmp;
     });
@@ -159,13 +221,15 @@ export default function ModelsPage() {
 
   const handleModelSort = (col: string) => {
     if (modelSortCol === col) setModelSortReverse(r => !r);
-    else { setModelSortCol(col); setModelSortReverse(false); }
+    else {
+      setModelSortCol(col);
+      setModelSortReverse(false);
+    }
   };
 
   // ── Actions ──────────────────────────────────────────────────────────────────
 
-  const patchForm = (k: keyof typeof form, v: unknown) =>
-    setForm(f => ({ ...f, [k]: v }));
+  const patchForm = (k: keyof typeof form, v: unknown) => setForm(f => ({ ...f, [k]: v }));
 
   const toggleStrategy = (strategy: string) => {
     setForm(f => ({
@@ -226,7 +290,12 @@ export default function ModelsPage() {
   };
 
   const deleteSession = async (id: string) => {
-    if (!confirm('Hard-delete this session? This also removes its model and all associated agent runs.')) return;
+    if (
+      !confirm(
+        'Hard-delete this session? This also removes its model and all associated agent runs.'
+      )
+    )
+      return;
     setDeleting(id);
     try {
       await agentFetch(`/training/sessions/${id}`, { method: 'DELETE' });
@@ -237,6 +306,44 @@ export default function ModelsPage() {
       toast.error(e instanceof Error ? e.message : 'Failed to delete session.');
     } finally {
       setDeleting(null);
+    }
+  };
+
+  const renameSession = async (id: string, name: string) => {
+    await agentFetch(`/training/sessions/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    });
+    sessions.refetch();
+  };
+
+  const renameModel = async (id: string, name: string) => {
+    await agentFetch(`/training/models/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    });
+    models.refetch();
+    sessions.refetch();
+  };
+
+  const pushToBacktest = async (m: TrainedModel) => {
+    setPushingBacktest(m.id);
+    try {
+      await agentFetch('/agent/runs', {
+        method: 'POST',
+        body: JSON.stringify({
+          sessionId: m.sessionId,
+          name: `${m.name} — backtest`,
+          currency: m.session?.currency ?? 'BTC',
+          runType: 'BACKTEST',
+          initialCapitalBtc: 1,
+        }),
+      });
+      toast.success('Backtest queued — check the Agents page.');
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to queue backtest.');
+    } finally {
+      setPushingBacktest(null);
     }
   };
 
@@ -271,16 +378,48 @@ export default function ModelsPage() {
             <p className="text-sm font-semibold text-text-primary mb-4">Create Training Model</p>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <TextInput label="Name" placeholder="btc-ppo-v1" value={form.name} onChange={v => patchForm('name', v)} />
-              <TextInput label="Description (optional)" placeholder="Short description" value={form.description ?? ''} onChange={v => patchForm('description', v)} />
-              <SelectInput label="Currency" options={CURRENCY_OPTIONS} value={form.currency} onChange={v => patchForm('currency', v)} />
-              <SelectInput label="Algorithm" options={ALGORITHM_OPTIONS} value={form.algorithm ?? 'PPO'} onChange={v => patchForm('algorithm', v)} />
-              <TextInput label="Data From" type="date" value={form.dataFrom} onChange={v => patchForm('dataFrom', v)} />
-              <TextInput label="Data To" type="date" value={form.dataTo} onChange={v => patchForm('dataTo', v)} />
+              <TextInput
+                label="Name"
+                placeholder="btc-ppo-v1"
+                value={form.name}
+                onChange={v => patchForm('name', v)}
+              />
+              <TextInput
+                label="Description (optional)"
+                placeholder="Short description"
+                value={form.description ?? ''}
+                onChange={v => patchForm('description', v)}
+              />
+              <SelectInput
+                label="Currency"
+                options={CURRENCY_OPTIONS}
+                value={form.currency}
+                onChange={v => patchForm('currency', v)}
+              />
+              <SelectInput
+                label="Algorithm"
+                options={ALGORITHM_OPTIONS}
+                value={form.algorithm ?? 'PPO'}
+                onChange={v => patchForm('algorithm', v)}
+              />
+              <TextInput
+                label="Data From"
+                type="date"
+                value={form.dataFrom}
+                onChange={v => patchForm('dataFrom', v)}
+              />
+              <TextInput
+                label="Data To"
+                type="date"
+                value={form.dataTo}
+                onChange={v => patchForm('dataTo', v)}
+              />
             </div>
 
             <div className="mt-5">
-              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">Allowed Strategies</p>
+              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                Allowed Strategies
+              </p>
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
                 {STRATEGY_OPTIONS.map(s => {
                   const checked = form.allowedStrategies.includes(s.value);
@@ -290,7 +429,9 @@ export default function ModelsPage() {
                       type="button"
                       onClick={() => toggleStrategy(s.value)}
                       className={`text-left px-3 py-2.5 rounded-lg border-2 transition-colors ${
-                        checked ? 'border-brand bg-brand/5 text-brand' : 'border-input-border text-text-secondary hover:border-brand/50'
+                        checked
+                          ? 'border-brand bg-brand/5 text-brand'
+                          : 'border-input-border text-text-secondary hover:border-brand/50'
                       }`}
                     >
                       <div className="text-sm font-medium">{s.label}</div>
@@ -302,13 +443,22 @@ export default function ModelsPage() {
             </div>
 
             <div className="mt-5">
-              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">Risk Profile</p>
+              <p className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-3">
+                Risk Profile
+              </p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <SliderInput
                   label="Max Drawdown"
                   value={form.riskProfile.maxDrawdown * 100}
-                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 } }))}
-                  min={5} max={50} step={5}
+                  onChange={v =>
+                    setForm(f => ({
+                      ...f,
+                      riskProfile: { ...f.riskProfile, maxDrawdown: v / 100 },
+                    }))
+                  }
+                  min={5}
+                  max={50}
+                  step={5}
                   formatValue={v => `${v.toFixed(0)}%`}
                   minLabel="5% (tight)"
                   maxLabel="50% (loose)"
@@ -317,8 +467,15 @@ export default function ModelsPage() {
                 <SliderInput
                   label="Aggression Level"
                   value={form.riskProfile.aggressionLevel * 100}
-                  onChange={v => setForm(f => ({ ...f, riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 } }))}
-                  min={0} max={100} step={10}
+                  onChange={v =>
+                    setForm(f => ({
+                      ...f,
+                      riskProfile: { ...f.riskProfile, aggressionLevel: v / 100 },
+                    }))
+                  }
+                  min={0}
+                  max={100}
+                  step={10}
                   formatValue={v => aggressionLabel(v / 100)}
                   minLabel="Passive"
                   maxLabel="Aggressive"
@@ -328,12 +485,19 @@ export default function ModelsPage() {
             </div>
 
             <div className="flex gap-3 mt-5">
-              <button type="button" onClick={createSession} disabled={submitting}
-                className="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors">
+              <button
+                type="button"
+                onClick={createSession}
+                disabled={submitting}
+                className="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-opacity-90 disabled:opacity-50 transition-colors"
+              >
                 {submitting ? 'Queueing…' : 'Start Training'}
               </button>
-              <button type="button" onClick={() => setShowCreate(false)}
-                className="px-4 py-2 rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors">
+              <button
+                type="button"
+                onClick={() => setShowCreate(false)}
+                className="px-4 py-2 rounded-lg text-sm text-text-secondary hover:text-text-primary transition-colors"
+              >
                 Cancel
               </button>
             </div>
@@ -348,7 +512,9 @@ export default function ModelsPage() {
 
           {sessions.loading ? (
             <div className="space-y-2">
-              {[1, 2, 3].map(i => <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />)}
+              {[1, 2, 3].map(i => (
+                <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />
+              ))}
             </div>
           ) : sessions.error ? (
             <AgentError message={sessions.error} onRetry={sessions.refetch} />
@@ -381,7 +547,7 @@ export default function ModelsPage() {
                     {sessions.data?.length ? 'No sessions match your filters.' : 'No sessions yet.'}
                   </TableRowEmpty>
                 ) : (
-                  visibleSessions.map(s => (
+                  (visibleSessions.map(s => (
                     <TableRow
                       key={s.id}
                       colSpan={SESSION_HEADERS.length}
@@ -390,35 +556,47 @@ export default function ModelsPage() {
                       actionCol={
                         <div className="flex items-center justify-end gap-1">
                           {(s.status === 'QUEUED' || s.status === 'RUNNING') && (
-                            <button type="button" disabled={cancelling === s.id} onClick={() => cancelSession(s.id)}
+                            <button
+                              type="button"
+                              disabled={cancelling === s.id}
+                              onClick={() => cancelSession(s.id)}
                               title="Cancel"
-                              className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50">
+                              className="p-1.5 rounded text-yellow-400 hover:bg-yellow-400/20 transition-colors disabled:opacity-50"
+                            >
                               <FontAwesomeIcon icon={faBan} className="w-3 h-3" />
                             </button>
                           )}
-                          <button type="button" disabled={deleting === s.id} onClick={() => deleteSession(s.id)}
+                          <button
+                            type="button"
+                            disabled={deleting === s.id}
+                            onClick={() => deleteSession(s.id)}
                             title="Hard delete"
-                            className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50">
+                            className="p-1.5 rounded text-error hover:bg-error/20 transition-colors disabled:opacity-50"
+                          >
                             <FontAwesomeIcon icon={faTrash} className="w-3 h-3" />
                           </button>
                         </div>
                       }
                     >
                       <div className="text-left">
-                        <div className="font-medium text-text-primary">{s.name}</div>
-                        {s.description && <div className="text-text-muted text-xs">{s.description}</div>}
+                        <CellEditable value={s.name} onSave={v => renameSession(s.id, v)} />
+                        {s.description && (
+                          <div className="text-text-muted text-xs mt-0.5">{s.description}</div>
+                        )}
                       </div>
                       <span>{s.currency}</span>
                       <span>{s.algorithm}</span>
                       <span>
-                        <Badge text={s.status} variant="custom"
+                        <Badge
+                          text={s.status}
+                          variant="custom"
                           customColor={SESSION_STATUS_BADGE[s.status].color}
                           customBgColor={SESSION_STATUS_BADGE[s.status].bg}
                         />
                       </span>
                       <span className="text-text-muted">{fmtDate(s.createdAt)}</span>
                     </TableRow>
-                  )) as any
+                  )) as any)
                 )}
               </TableBody>
             </div>
@@ -433,7 +611,9 @@ export default function ModelsPage() {
 
           {models.loading ? (
             <div className="space-y-2">
-              {[1, 2].map(i => <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />)}
+              {[1, 2].map(i => (
+                <div key={i} className="h-14 bg-card rounded-lg animate-pulse" />
+              ))}
             </div>
           ) : models.error ? (
             <AgentError message={models.error} onRetry={models.refetch} />
@@ -458,34 +638,73 @@ export default function ModelsPage() {
                 tab={modelSortCol}
                 reverse={modelSortReverse}
                 tabOnChange={handleModelSort}
+                actionCol
               />
               <TableBody>
                 {visibleModels.length === 0 ? (
                   <TableRowEmpty>
-                    {models.data?.length ? 'No models match your filters.' : 'No trained models yet.'}
+                    {models.data?.length
+                      ? 'No models match your filters.'
+                      : 'No trained models yet.'}
                   </TableRowEmpty>
                 ) : (
-                  visibleModels.map(m => (
+                  (visibleModels.map(m => (
                     <TableRow
                       key={m.id}
                       colSpan={MODEL_HEADERS.length}
                       headers={MODEL_HEADERS}
                       tab={modelSortCol}
+                      actionCol={
+                        <div className="flex items-center justify-end">
+                          <button
+                            type="button"
+                            disabled={pushingBacktest === m.id}
+                            onClick={() => pushToBacktest(m)}
+                            title="Push to backtest"
+                            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium text-brand border border-brand/30 hover:bg-brand/10 transition-colors disabled:opacity-50"
+                          >
+                            <FontAwesomeIcon icon={faPlay} className="w-2.5 h-2.5" />
+                            {pushingBacktest === m.id ? 'Queuing…' : 'Backtest'}
+                          </button>
+                        </div>
+                      }
                     >
                       <div className="text-left">
-                        <div className="font-medium text-text-primary">{m.name}</div>
-                        <div className="text-text-muted text-xs font-mono truncate max-w-[16rem]" title={m.storagePath}>
+                        <CellEditable
+                          value={resolveModelName(m)}
+                          onSave={v => renameModel(m.id, v)}
+                        />
+                        <div
+                          className="text-text-muted text-xs font-mono truncate max-w-[16rem]"
+                          title={m.storagePath}
+                        >
                           {m.storagePath}
                         </div>
                       </div>
                       <span className="text-text-secondary">{m.session?.algorithm ?? '—'}</span>
-                      <span className={m.sharpeRatio !== undefined ? (m.sharpeRatio >= 1 ? 'text-success font-mono' : 'text-text-primary font-mono') : 'text-text-muted'}>
+                      <span
+                        className={
+                          m.sharpeRatio !== undefined
+                            ? m.sharpeRatio >= 1
+                              ? 'text-success font-mono'
+                              : 'text-text-primary font-mono'
+                            : 'text-text-muted'
+                        }
+                      >
                         {m.sharpeRatio !== undefined ? fmt(m.sharpeRatio, 2) : '—'}
                       </span>
                       <span className="font-mono text-text-primary">
                         {m.maxDrawdown !== undefined ? `${fmt(m.maxDrawdown, 1)}%` : '—'}
                       </span>
-                      <span className={m.winRate !== undefined ? (m.winRate >= 0.5 ? 'text-success font-mono' : 'text-text-primary font-mono') : 'text-text-muted'}>
+                      <span
+                        className={
+                          m.winRate !== undefined
+                            ? m.winRate >= 0.5
+                              ? 'text-success font-mono'
+                              : 'text-text-primary font-mono'
+                            : 'text-text-muted'
+                        }
+                      >
                         {m.winRate !== undefined ? `${fmt(m.winRate * 100, 1)}%` : '—'}
                       </span>
                       <span className="font-mono text-text-primary">
@@ -494,7 +713,7 @@ export default function ModelsPage() {
                       <span className="text-text-secondary">{fmtSize(m.sizeBytes)}</span>
                       <span className="text-text-muted">{fmtDate(m.createdAt)}</span>
                     </TableRow>
-                  )) as any
+                  )) as any)
                 )}
               </TableBody>
             </div>

--- a/pages/deribit-agent/models.tsx
+++ b/pages/deribit-agent/models.tsx
@@ -53,9 +53,7 @@ const MODEL_HEADERS = [
   'Obs Space',
   'Policy',
   'Algorithm',
-  'Sharpe',
-  'Max DD',
-  'Win Rate',
+  'Trained On',
   'Mean Reward',
   'Size',
   'Created',
@@ -93,6 +91,13 @@ function aggressionLabel(level: number): string {
 // show the session name as the human-readable fallback.
 function resolveModelName(m: TrainedModel): string {
   return /_(ppo|dqn|a2c)$/i.test(m.name) ? (m.session?.name ?? m.name) : m.name;
+}
+
+function fmtSteps(n?: number | null): string {
+  if (!n) return '—';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000)     return `${Math.round(n / 1_000)}k`;
+  return String(n);
 }
 
 function fmtSize(bytes?: number): string {
@@ -205,14 +210,8 @@ export default function ModelsPage() {
         case 'Algorithm':
           cmp = (a.session?.algorithm ?? '').localeCompare(b.session?.algorithm ?? '');
           break;
-        case 'Sharpe':
-          cmp = (a.sharpeRatio ?? -Infinity) - (b.sharpeRatio ?? -Infinity);
-          break;
-        case 'Max DD':
-          cmp = (a.maxDrawdown ?? -Infinity) - (b.maxDrawdown ?? -Infinity);
-          break;
-        case 'Win Rate':
-          cmp = (a.winRate ?? -Infinity) - (b.winRate ?? -Infinity);
+        case 'Trained On':
+          cmp = (a.session?.totalTimesteps ?? 0) - (b.session?.totalTimesteps ?? 0);
           break;
         case 'Mean Reward':
           cmp = (a.meanReward ?? -Infinity) - (b.meanReward ?? -Infinity);
@@ -696,18 +695,10 @@ export default function ModelsPage() {
                         </div>
                       }
                     >
-                      <div className="text-left">
-                        <CellEditable
-                          value={resolveModelName(m)}
-                          onSave={v => renameModel(m.id, v)}
-                        />
-                        <div
-                          className="text-text-muted text-xs font-mono truncate max-w-[16rem]"
-                          title={m.storagePath}
-                        >
-                          {m.storagePath}
-                        </div>
-                      </div>
+                      <CellEditable
+                        value={resolveModelName(m)}
+                        onSave={v => renameModel(m.id, v)}
+                      />
                       <div className="font-mono text-xs">
                         {m.metadata?.obs_version && m.metadata?.obs_dims ? (
                           <>
@@ -723,30 +714,8 @@ export default function ModelsPage() {
                         {m.metadata?.policy ?? '—'}
                       </span>
                       <span className="text-text-secondary">{m.session?.algorithm ?? '—'}</span>
-                      <span
-                        className={
-                          m.sharpeRatio !== undefined
-                            ? m.sharpeRatio >= 1
-                              ? 'text-success font-mono'
-                              : 'text-text-primary font-mono'
-                            : 'text-text-muted'
-                        }
-                      >
-                        {m.sharpeRatio !== undefined ? fmt(m.sharpeRatio, 2) : '—'}
-                      </span>
-                      <span className="font-mono text-text-primary">
-                        {m.maxDrawdown !== undefined ? `${fmt(m.maxDrawdown, 1)}%` : '—'}
-                      </span>
-                      <span
-                        className={
-                          m.winRate !== undefined
-                            ? m.winRate >= 0.5
-                              ? 'text-success font-mono'
-                              : 'text-text-primary font-mono'
-                            : 'text-text-muted'
-                        }
-                      >
-                        {m.winRate !== undefined ? `${fmt(m.winRate * 100, 1)}%` : '—'}
+                      <span className="font-mono text-text-secondary">
+                        {fmtSteps(m.session?.totalTimesteps)}
                       </span>
                       <span className="font-mono text-text-primary">
                         {m.meanReward !== undefined ? fmt(m.meanReward, 3) : '—'}

--- a/pages/deribit-agent/models.tsx
+++ b/pages/deribit-agent/models.tsx
@@ -37,22 +37,21 @@ const ALGORITHM_OPTIONS = [
 ];
 
 const STRATEGY_OPTIONS = [
-  { value: 'STRANGLE', label: 'Strangle', desc: 'Sell OTM call + put simultaneously' },
-  { value: 'STRADDLE', label: 'Straddle', desc: 'Sell ATM call + put' },
-  { value: 'DELTA_NEUTRAL', label: 'Delta Neutral', desc: 'Hedge to near-zero net delta' },
-  { value: 'COVERED_CALL', label: 'Covered Call', desc: 'Sell calls against a long position' },
+  { value: 'short_call', label: 'Short Call', desc: 'Sell calls at any delta (Δ20–Δ80)' },
+  { value: 'short_put', label: 'Short Put', desc: 'Sell puts at any delta (Δ10–Δ50)' },
   {
-    value: 'CASH_SECURED_PUT',
-    label: 'Cash-Secured Put',
-    desc: 'Sell puts with full margin reserved',
+    value: 'delta_neutral',
+    label: 'Delta Neutral',
+    desc: 'Balanced call + put positioning, including one-action strangles',
   },
-  { value: 'IRON_CONDOR', label: 'Iron Condor', desc: 'Sell OTM strangle, buy further OTM wings' },
 ];
 
 const SESSION_STATUSES = ['QUEUED', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'];
 const SESSION_HEADERS = ['Name', 'Currency', 'Algorithm', 'Status', 'Created'];
 const MODEL_HEADERS = [
   'Name',
+  'Obs Space',
+  'Policy',
   'Algorithm',
   'Sharpe',
   'Max DD',
@@ -66,6 +65,8 @@ const MODEL_STORAGE_TYPES = ['local', 's3'];
 const BLANK_SESSION: CreateSessionBody & {
   allowedStrategies: string[];
   riskProfile: Required<RiskProfile>;
+  totalTimesteps: number;
+  learningRate: number;
 } = {
   name: '',
   description: '',
@@ -74,8 +75,10 @@ const BLANK_SESSION: CreateSessionBody & {
   dataTo: new Date().toISOString().slice(0, 10),
   resolution: '1D',
   algorithm: 'PPO',
-  allowedStrategies: ['STRANGLE', 'DELTA_NEUTRAL'],
+  allowedStrategies: ['short_call', 'short_put', 'delta_neutral'],
   riskProfile: { maxDrawdown: 0.2, aggressionLevel: 0.5 },
+  totalTimesteps: 100_000,
+  learningRate: 0.005,
 };
 
 function aggressionLabel(level: number): string {
@@ -193,6 +196,12 @@ export default function ModelsPage() {
         case 'Name':
           cmp = a.name.localeCompare(b.name);
           break;
+        case 'Obs Space':
+          cmp = (a.metadata?.obs_dims ?? 0) - (b.metadata?.obs_dims ?? 0);
+          break;
+        case 'Policy':
+          cmp = (a.metadata?.policy ?? '').localeCompare(b.metadata?.policy ?? '');
+          break;
         case 'Algorithm':
           cmp = (a.session?.algorithm ?? '').localeCompare(b.session?.algorithm ?? '');
           break;
@@ -263,6 +272,12 @@ export default function ModelsPage() {
           algorithm: form.algorithm,
           allowedStrategies: form.allowedStrategies,
           riskProfile: form.riskProfile,
+          hyperparams: {
+            training: {
+              total_timesteps: form.totalTimesteps,
+              learning_rate:   form.learningRate,
+            },
+          },
         } satisfies CreateSessionBody),
       });
       toast.success('Training session queued.');
@@ -413,6 +428,18 @@ export default function ModelsPage() {
                 type="date"
                 value={form.dataTo}
                 onChange={v => patchForm('dataTo', v)}
+              />
+              <TextInput
+                label="Total Timesteps"
+                type="number"
+                value={String(form.totalTimesteps)}
+                onChange={v => patchForm('totalTimesteps', Math.max(1, parseInt(v) || 100_000))}
+              />
+              <TextInput
+                label="Learning Rate"
+                type="number"
+                value={String(form.learningRate)}
+                onChange={v => patchForm('learningRate', Math.max(0, parseFloat(v) || 0.005))}
               />
             </div>
 
@@ -681,6 +708,20 @@ export default function ModelsPage() {
                           {m.storagePath}
                         </div>
                       </div>
+                      <div className="font-mono text-xs">
+                        {m.metadata?.obs_version && m.metadata?.obs_dims ? (
+                          <>
+                            <span className="text-text-secondary">{m.metadata.obs_version}</span>
+                            <span className="text-text-muted mx-1">·</span>
+                            <span className="text-text-primary">{m.metadata.obs_dims}f</span>
+                          </>
+                        ) : (
+                          <span className="text-text-muted">—</span>
+                        )}
+                      </div>
+                      <span className="text-text-secondary text-xs font-mono">
+                        {m.metadata?.policy ?? '—'}
+                      </span>
                       <span className="text-text-secondary">{m.session?.algorithm ?? '—'}</span>
                       <span
                         className={

--- a/pages/deribit-agent/settings.tsx
+++ b/pages/deribit-agent/settings.tsx
@@ -430,12 +430,6 @@ export default function DeribitSettingsPage() {
                 example: 'http://localhost:3030',
                 note: 'Origin only — no path, no API key',
               },
-              {
-                key: 'NEXT_PUBLIC_DERIBIT_AGENT_API_KEY',
-                val: process.env.NEXT_PUBLIC_DERIBIT_AGENT_API_KEY,
-                example: 'rw_prod_<keyId>.<secret>',
-                note: 'Sent as X-API-Key header on every request',
-              },
             ] as const).map(({ key, val, example, note }) => (
               <div key={key}>
                 <div className="flex items-center gap-3">
@@ -452,9 +446,11 @@ export default function DeribitSettingsPage() {
           </div>
           <div className="mt-4 bg-surface rounded-lg p-3 font-mono text-xs text-text-secondary space-y-1">
             <p className="text-text-muted mb-1"># .env.local</p>
-            <p>NEXT_PUBLIC_DERIBIT_AGENT_URL=http://localhost:3030</p>
-            <p>NEXT_PUBLIC_DERIBIT_AGENT_API_KEY=rw_prod_{'<keyId>.<secret>'}</p>
+            <p>NEXT_PUBLIC_DERIBIT_AGENT_URL=http://localhost:3031</p>
           </div>
+          <p className="text-text-muted text-xs mt-3">
+            Requests are authenticated with your wrytes-api JWT (<span className="font-mono">Authorization: Bearer</span>). No API key needed.
+          </p>
         </Card>
       </Section>
     </>


### PR DESCRIPTION
## Summary

- **Continue Training mode** — models page gets a New / Continue Training toggle; continue mode shows a completed-model selector with inherited currency, algorithm, and obs_version badges; sends \`resumeFromModelId\` to the API
- **Accumulated timesteps** — resumed sessions display cumulative base + new timesteps in the Trained On column
- **BTC Price vs Strikes chart fix** — strike lines no longer bridge closed-position gaps: replaced single-variable state with a per-instrument Map (open/close matched by exact instrument name) and added \`spanGaps: false\` to strike datasets so nulls render as gaps
- **Agent page** — flush pending settings debounce before execute; continuous equity chart via hold events

## Test plan
- [ ] Continue Training selector shows only completed models with currency/algorithm/obs badges
- [ ] Submitting a continued session sends \`resumeFromModelId\` (no \`currency\`); queues successfully
- [ ] After completion, Trained On = base + new timesteps
- [ ] Strikes chart: lines only appear while positions are open; no bridging across closed gaps
- [ ] Execute always uses latest settings even when slider moved within debounce window

🤖 Generated with [Claude Code](https://claude.com/claude-code)